### PR TITLE
More go-friendly representation for changes.

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -12,7 +12,7 @@ import (
 // FromData generates and returns the list of changes required to deploy the
 // given bundle data. The changes are sorted by requirements, so that they can
 // be applied in order. The bundle data is assumed to be already verified.
-func FromData(data *charm.BundleData) []*Change {
+func FromData(data *charm.BundleData) []Change {
 	cs := &changeset{}
 	addedServices := handleServices(cs.add, data.Services)
 	addedMachines := handleMachines(cs.add, data.Machines)
@@ -22,54 +22,294 @@ func FromData(data *charm.BundleData) []*Change {
 }
 
 // Change holds a single change required to deploy a bundle.
-type Change struct {
-	// Id is the unique identifier for this change.
-	Id string `json:"id"`
-	// Method is the action to be performed to apply this change.
-	Method string `json:"method"`
-	// Args holds a list of arguments to pass to the method.
-	Args []interface{} `json:"args"`
-	// Requires holds a list of dependencies for this change. Each dependency
+type Change interface {
+	// Id returns the unique identifier for this change.
+	Id() string
+	// Requires returns a list of dependencies for this change. Each dependency
 	// is represented by the corresponding change id, and must be applied
 	// before this change is applied.
-	Requires []string `json:"requires"`
+	Requires() []string
+	// Method returns the action to be performed to apply this change.
+	Method() string
+	// GUIArgs returns positional arguments to pass to the method, suitable for
+	// being serialized and sent to the Juju GUI.
+	GUIArgs() []interface{}
+	// setId is used to set the identifier for the change.
+	setId(string)
+}
+
+type changeInfo struct {
+	id       string
+	requires []string
+	method   string
+}
+
+// Id implements Change.Id.
+func (ch *changeInfo) Id() string {
+	return ch.id
+}
+
+// Requires implements Change.Requires.
+func (ch *changeInfo) Requires() []string {
+	if ch.requires == nil {
+		return make([]string, 0)
+	}
+	return ch.requires
+}
+
+// Method implements Change.Method.
+func (ch *changeInfo) Method() string {
+	return ch.method
+}
+
+// setId implements Change.setId.
+func (ch *changeInfo) setId(id string) {
+	ch.id = id
+}
+
+// newAddCharmChange creates a new change for adding a charm.
+func newAddCharmChange(args AddCharmArgs, requires ...string) *AddCharmChange {
+	return &AddCharmChange{
+		changeInfo: changeInfo{
+			requires: requires,
+			method:   "addCharm",
+		},
+		Args: args,
+	}
+}
+
+// AddCharmChange holds a change for adding a charm to the environment.
+type AddCharmChange struct {
+	changeInfo
+	// Args holds parameters for adding a charm.
+	Args AddCharmArgs
+}
+
+// GUIArgs implements Change.GUIArgs.
+func (ch *AddCharmChange) GUIArgs() []interface{} {
+	return []interface{}{ch.Args.Charm}
+}
+
+// AddCharmArgs holds parameters for adding a charm to the environment.
+type AddCharmArgs struct {
+	// Charm holds the URL of the charm to be added.
+	Charm string
+}
+
+// newAddMachineChange creates a new change for adding a machine or container.
+func newAddMachineChange(args AddMachineArgs, requires ...string) *AddMachineChange {
+	return &AddMachineChange{
+		changeInfo: changeInfo{
+			requires: requires,
+			method:   "addMachines",
+		},
+		Args: args,
+	}
+}
+
+// AddMachineChange holds a change for adding a machine or container.
+type AddMachineChange struct {
+	changeInfo
+	// Args holds parameters for adding a machine.
+	Args AddMachineArgs
+}
+
+// GUIArgs implements Change.GUIArgs.
+func (ch *AddMachineChange) GUIArgs() []interface{} {
+	options := AddMachineOptions{
+		Series:        ch.Args.Series,
+		Constraints:   ch.Args.Constraints,
+		ContainerType: ch.Args.ContainerType,
+		ParentId:      ch.Args.ParentId,
+	}
+	return []interface{}{options}
+}
+
+// AddMachineOptions holds GUI options for adding a machine or container.
+type AddMachineOptions struct {
+	// Series holds the machine OS series.
+	Series string `json:"series,omitempty"`
+	// Constraints holds the machine constraints.
+	Constraints string `json:"constraints,omitempty"`
+	// ContainerType holds the machine container type (like "lxc" or "kvm").
+	ContainerType string `json:"containerType,omitempty"`
+	// ParentId holds the id of the parent machine.
+	ParentId string `json:"parentId,omitempty"`
+}
+
+// AddMachineArgs holds parameters for adding a machine or container.
+type AddMachineArgs struct {
+	// Series holds the optional machine OS series.
+	Series string
+	// Constraints holds the optional machine constraints.
+	Constraints string
+	// ContainerType optionally holds the type of the container (for instance
+	// ""lxc" or kvm"). It is not specified for top level machines.
+	ContainerType string
+	// ParentId optionally holds a placeholder pointing to another machine
+	// change or to a unit change. This value is only specified in the case
+	// this machine is a container, in which case also ContainerType is set.
+	ParentId string
+}
+
+// newAddRelationChange creates a new change for adding a relation.
+func newAddRelationChange(args AddRelationArgs, requires ...string) *AddRelationChange {
+	return &AddRelationChange{
+		changeInfo: changeInfo{
+			requires: requires,
+			method:   "addRelation",
+		},
+		Args: args,
+	}
+}
+
+// AddRelationChange holds a change for adding a relation between two services.
+type AddRelationChange struct {
+	changeInfo
+	// Args holds parameters for adding a relation.
+	Args AddRelationArgs
+}
+
+// GUIArgs implements Change.GUIArgs.
+func (ch *AddRelationChange) GUIArgs() []interface{} {
+	return []interface{}{ch.Args.Endpoint1, ch.Args.Endpoint2}
+}
+
+// AddRelationArgs holds parameters for adding a relation between two services.
+type AddRelationArgs struct {
+	// Endpoint1 and Endpoint2 hold relation endpoints, like "$deploy-1:web" or
+	// just "$deploy-1". The service part of the endpoint is always a
+	// placeholder pointing to a service change.
+	Endpoint1 string
+	Endpoint2 string
+}
+
+// newAddServiceChange creates a new change for adding a service.
+func newAddServiceChange(args AddServiceArgs, requires ...string) *AddServiceChange {
+	return &AddServiceChange{
+		changeInfo: changeInfo{
+			requires: requires,
+			method:   "deploy",
+		},
+		Args: args,
+	}
+}
+
+// AddServiceChange holds a change for deploying a Juju service.
+type AddServiceChange struct {
+	changeInfo
+	// Args holds parameters for adding a service.
+	Args AddServiceArgs
+}
+
+// GUIArgs implements Change.GUIArgs.
+func (ch *AddServiceChange) GUIArgs() []interface{} {
+	options := ch.Args.Options
+	if options == nil {
+		options = make(map[string]interface{}, 0)
+	}
+	return []interface{}{ch.Args.Charm, ch.Args.Service, options}
+}
+
+// AddServiceArgs holds parameters for deploying a Juju service.
+type AddServiceArgs struct {
+	// Charm holds the URL of the charm to be used to deploy this service.
+	Charm string
+	// Service holds the service name.
+	Service string
+	// Options holds service options.
+	Options map[string]interface{}
+	// TODO frankban: add support for service constraints.
+}
+
+// newAddUnitChange creates a new change for adding a service unit.
+func newAddUnitChange(args AddUnitArgs, requires ...string) *AddUnitChange {
+	return &AddUnitChange{
+		changeInfo: changeInfo{
+			requires: requires,
+			method:   "addUnit",
+		},
+		Args: args,
+	}
+}
+
+// AddUnitChange holds a change for adding a service unit.
+type AddUnitChange struct {
+	changeInfo
+	// Args holds parameters for adding a unit.
+	Args AddUnitArgs
+}
+
+// GUIArgs implements Change.GUIArgs.
+func (ch *AddUnitChange) GUIArgs() []interface{} {
+	args := []interface{}{ch.Args.Service, 1, nil}
+	if ch.Args.To != "" {
+		args[2] = ch.Args.To
+	}
+	return args
+}
+
+// AddUnitArgs holds parameters for adding a service unit.
+type AddUnitArgs struct {
+	// Service holds the service placeholder name for which a unit is added.
+	Service string
+	// To holds the optional location where to add the unit, as a placeholder
+	// pointing to another unit change or to a machine change.
+	To string
+}
+
+// newSetAnnotationsChange creates a new change for setting annotations.
+func newSetAnnotationsChange(args SetAnnotationsArgs, requires ...string) *SetAnnotationsChange {
+	return &SetAnnotationsChange{
+		changeInfo: changeInfo{
+			requires: requires,
+			method:   "setAnnotations",
+		},
+		Args: args,
+	}
+}
+
+// SetAnnotationsChange holds a change for setting service and machine
+// annotations.
+type SetAnnotationsChange struct {
+	changeInfo
+	// Args holds parameters for setting annotations.
+	Args SetAnnotationsArgs
+}
+
+// GUIArgs implements Change.GUIArgs.
+func (ch *SetAnnotationsChange) GUIArgs() []interface{} {
+	return []interface{}{ch.Args.Id, ch.Args.EntityType, ch.Args.Annotations}
+}
+
+// AddServiceArgs holds parameters for setting annotations.
+type SetAnnotationsArgs struct {
+	// Id is the placeholder for the service or machine change corresponding to
+	// the entity to be annotated.
+	Id string
+	// EntityType holds the type of the entity, "service" or "machine".
+	EntityType string
+	// Annotations holds the annotations as key/value pairs.
+	Annotations map[string]string
 }
 
 // changeset holds the list of changes returned by FromData.
 type changeset struct {
-	changes []*Change
+	changes []Change
 }
 
-// add is an addChangeFunc that can be used to add a change to this change set.
-func (cs *changeset) add(method string, requires []string, args ...interface{}) *Change {
-	if args == nil {
-		args = make([]interface{}, 0)
-	}
-	if requires == nil {
-		requires = make([]string, 0)
-	}
-	// TODO frankban: current Python bundle lib includes this inconsistency;
-	// break compatibility and just use addService?
-	idPrefix := method
-	if method == "deploy" {
-		idPrefix = "addService"
-	}
-	change := &Change{
-		Id:       fmt.Sprintf("%s-%d", idPrefix, len(cs.changes)),
-		Method:   method,
-		Args:     args,
-		Requires: requires,
-	}
+// add adds the given change to this change set.
+func (cs *changeset) add(change Change) {
+	change.setId(fmt.Sprintf("%s-%d", change.Method(), len(cs.changes)))
 	cs.changes = append(cs.changes, change)
-	return change
 }
 
 // sorted returns the changes sorted by requirements, required first.
-func (cs *changeset) sorted() []*Change {
+func (cs *changeset) sorted() []Change {
 	numChanges := len(cs.changes)
 	records := make(map[string]bool, numChanges)
-	sorted := make([]*Change, 0, numChanges)
-	changes := make([]*Change, numChanges, numChanges*2)
+	sorted := make([]Change, 0, numChanges)
+	changes := make([]Change, numChanges, numChanges*2)
 	copy(changes, cs.changes)
 mainloop:
 	for len(changes) != 0 {
@@ -77,7 +317,7 @@ mainloop:
 		// (add one charm and deploy one service).
 		change := changes[0]
 		changes = changes[1:]
-		for _, r := range change.Requires {
+		for _, r := range change.Requires() {
 			if !records[r] {
 				// This change requires a change which is not yet listed.
 				// Push this change at the end of the list and retry later.
@@ -85,7 +325,7 @@ mainloop:
 				continue mainloop
 			}
 		}
-		records[change.Id] = true
+		records[change.Id()] = true
 		sorted = append(sorted, change)
 	}
 	return sorted

--- a/changes.go
+++ b/changes.go
@@ -52,7 +52,7 @@ func (ch *changeInfo) Id() string {
 // Requires implements Change.Requires.
 func (ch *changeInfo) Requires() []string {
 	if ch.requires == nil {
-		return make([]string, 0)
+		return []string{}
 	}
 	return ch.requires
 }

--- a/changes_test.go
+++ b/changes_test.go
@@ -29,7 +29,7 @@ var fromDataTests = []struct {
 	// content is the YAML encoded bundle content.
 	content string
 	// expected holds the expected changes required to deploy the bundle.
-	expected []*bundlechanges.Change
+	expected []record
 }{{
 	about: "minimal bundle",
 	content: `
@@ -37,14 +37,21 @@ var fromDataTests = []struct {
             django:
                 charm: django
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"django"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "django",
+		},
+		GUIArgs: []interface{}{"django"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "django",
+			Service: "django",
+		},
+		GUIArgs: []interface{}{
 			"django",
 			"django",
 			map[string]interface{}{},
@@ -71,14 +78,21 @@ var fromDataTests = []struct {
             - - mediawiki:db
               - mysql:db
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:precise/mediawiki-10"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:precise/mediawiki-10",
+		},
+		GUIArgs: []interface{}{"cs:precise/mediawiki-10"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:precise/mediawiki-10",
+			Service: "mediawiki",
+			Options: map[string]interface{}{"debug": false}},
+		GUIArgs: []interface{}{
 			"cs:precise/mediawiki-10",
 			"mediawiki",
 			map[string]interface{}{"debug": false},
@@ -87,40 +101,62 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "setAnnotations-2",
 		Method: "setAnnotations",
-		Args: []interface{}{
-			"$addService-1",
+		Args: bundlechanges.SetAnnotationsArgs{
+			Id:          "$deploy-1",
+			EntityType:  "service",
+			Annotations: map[string]string{"gui-x": "609", "gui-y": "-15"},
+		},
+		GUIArgs: []interface{}{
+			"$deploy-1",
 			"service",
 			map[string]string{"gui-x": "609", "gui-y": "-15"},
 		},
-		Requires: []string{"addService-1"},
+		Requires: []string{"deploy-1"},
 	}, {
 		Id:     "addCharm-3",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:precise/mysql-28"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:precise/mysql-28",
+		},
+		GUIArgs: []interface{}{"cs:precise/mysql-28"},
 	}, {
-		Id:     "addService-4",
+		Id:     "deploy-4",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:precise/mysql-28",
+			Service: "mysql",
+		},
+		GUIArgs: []interface{}{
 			"cs:precise/mysql-28",
 			"mysql",
 			map[string]interface{}{},
 		},
 		Requires: []string{"addCharm-3"},
 	}, {
-		Id:       "addRelation-5",
-		Method:   "addRelation",
-		Args:     []interface{}{"$addService-1:db", "$addService-4:db"},
-		Requires: []string{"addService-1", "addService-4"},
+		Id:     "addRelation-5",
+		Method: "addRelation",
+		Args: bundlechanges.AddRelationArgs{
+			Endpoint1: "$deploy-1:db",
+			Endpoint2: "$deploy-4:db",
+		},
+		GUIArgs:  []interface{}{"$deploy-1:db", "$deploy-4:db"},
+		Requires: []string{"deploy-1", "deploy-4"},
 	}, {
-		Id:       "addUnit-6",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, nil},
-		Requires: []string{"addService-1"},
+		Id:     "addUnit-6",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, nil},
+		Requires: []string{"deploy-1"},
 	}, {
-		Id:       "addUnit-7",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-4", 1, nil},
-		Requires: []string{"addService-4"},
+		Id:     "addUnit-7",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-4",
+		},
+		GUIArgs:  []interface{}{"$deploy-4", 1, nil},
+		Requires: []string{"deploy-4"},
 	}},
 }, {
 	about: "machines and units placement",
@@ -146,14 +182,21 @@ var fromDataTests = []struct {
                 series: trusty
             2:
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/django-42"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:trusty/django-42",
+		},
+		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:trusty/django-42",
+			Service: "django",
+		},
+		GUIArgs: []interface{}{
 			"cs:trusty/django-42",
 			"django",
 			map[string]interface{}{},
@@ -162,11 +205,19 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/haproxy-47"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:trusty/haproxy-47",
+		},
+		GUIArgs: []interface{}{"cs:trusty/haproxy-47"},
 	}, {
-		Id:     "addService-3",
+		Id:     "deploy-3",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:trusty/haproxy-47",
+			Service: "haproxy",
+			Options: map[string]interface{}{"bad": "wolf", "number": 42.47},
+		},
+		GUIArgs: []interface{}{
 			"cs:trusty/haproxy-47",
 			"haproxy",
 			map[string]interface{}{"bad": "wolf", "number": 42.47},
@@ -175,54 +226,90 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-4",
 		Method: "addMachines",
-		Args: []interface{}{
-			map[string]string{"series": "trusty", "constraints": ""},
+		Args: bundlechanges.AddMachineArgs{
+			Series: "trusty",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{Series: "trusty"},
 		},
 	}, {
 		Id:     "addMachines-5",
 		Method: "addMachines",
-		Args: []interface{}{
-			map[string]string{"series": "", "constraints": ""},
+		Args:   bundlechanges.AddMachineArgs{},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{},
 		},
 	}, {
-		Id:       "addUnit-6",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-4"},
-		Requires: []string{"addService-1", "addMachines-4"},
+		Id:     "addUnit-6",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-4",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-4"},
+		Requires: []string{"deploy-1", "addMachines-4"},
 	}, {
 		Id:     "addMachines-10",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"containerType": "lxc",
-			"parentId":      "$addMachines-5",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "lxc",
+			ParentId:      "$addMachines-5",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "lxc",
+				ParentId:      "$addMachines-5",
+			},
+		},
 		Requires: []string{"addMachines-5"},
 	}, {
 		Id:     "addMachines-11",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"containerType": "lxc",
-			"parentId":      "$addUnit-6",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "lxc",
+			ParentId:      "$addUnit-6",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "lxc",
+				ParentId:      "$addUnit-6",
+			},
+		},
 		Requires: []string{"addUnit-6"},
 	}, {
 		Id:     "addMachines-12",
 		Method: "addMachines",
+		Args:   bundlechanges.AddMachineArgs{},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{},
+		},
 	}, {
-		Id:       "addUnit-7",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-10"},
-		Requires: []string{"addService-1", "addMachines-10"},
+		Id:     "addUnit-7",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-10",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-10"},
+		Requires: []string{"deploy-1", "addMachines-10"},
 	}, {
-		Id:       "addUnit-8",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, "$addMachines-11"},
-		Requires: []string{"addService-3", "addMachines-11"},
+		Id:     "addUnit-8",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+			To:      "$addMachines-11",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, "$addMachines-11"},
+		Requires: []string{"deploy-3", "addMachines-11"},
 	}, {
-		Id:       "addUnit-9",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, "$addMachines-12"},
-		Requires: []string{"addService-3", "addMachines-12"},
+		Id:     "addUnit-9",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+			To:      "$addMachines-12",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, "$addMachines-12"},
+		Requires: []string{"deploy-3", "addMachines-12"},
 	}},
 }, {
 	about: "machines with constraints and annotations",
@@ -240,14 +327,21 @@ var fromDataTests = []struct {
                 annotations:
                     foo: bar
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/django-42"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:trusty/django-42",
+		},
+		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:trusty/django-42",
+			Service: "django",
+		},
+		GUIArgs: []interface{}{
 			"cs:trusty/django-42",
 			"django",
 			map[string]interface{}{},
@@ -256,31 +350,51 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-2",
 		Method: "addMachines",
-		Args: []interface{}{
-			map[string]string{"series": "", "constraints": "cpu-cores=4"},
+		Args: bundlechanges.AddMachineArgs{
+			Constraints: "cpu-cores=4",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{Constraints: "cpu-cores=4"},
 		},
 	}, {
 		Id:     "setAnnotations-3",
 		Method: "setAnnotations",
-		Args: []interface{}{
+		Args: bundlechanges.SetAnnotationsArgs{
+			Id:          "$addMachines-2",
+			EntityType:  "machine",
+			Annotations: map[string]string{"foo": "bar"},
+		},
+		GUIArgs: []interface{}{
 			"$addMachines-2",
 			"machine",
 			map[string]string{"foo": "bar"},
 		},
 		Requires: []string{"addMachines-2"},
 	}, {
-		Id:       "addUnit-4",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-2"},
-		Requires: []string{"addService-1", "addMachines-2"},
+		Id:     "addUnit-4",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-2",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-2"},
+		Requires: []string{"deploy-1", "addMachines-2"},
 	}, {
 		Id:     "addMachines-6",
 		Method: "addMachines",
+		Args:   bundlechanges.AddMachineArgs{},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{},
+		},
 	}, {
-		Id:       "addUnit-5",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-6"},
-		Requires: []string{"addService-1", "addMachines-6"},
+		Id:     "addUnit-5",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-6",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-6"},
+		Requires: []string{"deploy-1", "addMachines-6"},
 	}},
 }, {
 	about: "endpoint without relation name",
@@ -294,14 +408,21 @@ var fromDataTests = []struct {
             - - mediawiki:db
               - mysql
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:precise/mediawiki-10"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:precise/mediawiki-10",
+		},
+		GUIArgs: []interface{}{"cs:precise/mediawiki-10"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:precise/mediawiki-10",
+			Service: "mediawiki",
+		},
+		GUIArgs: []interface{}{
 			"cs:precise/mediawiki-10",
 			"mediawiki",
 			map[string]interface{}{},
@@ -310,21 +431,32 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:precise/mysql-28"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:precise/mysql-28",
+		},
+		GUIArgs: []interface{}{"cs:precise/mysql-28"},
 	}, {
-		Id:     "addService-3",
+		Id:     "deploy-3",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:precise/mysql-28",
+			Service: "mysql",
+		},
+		GUIArgs: []interface{}{
 			"cs:precise/mysql-28",
 			"mysql",
 			map[string]interface{}{},
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
-		Id:       "addRelation-4",
-		Method:   "addRelation",
-		Args:     []interface{}{"$addService-1:db", "$addService-3"},
-		Requires: []string{"addService-1", "addService-3"},
+		Id:     "addRelation-4",
+		Method: "addRelation",
+		Args: bundlechanges.AddRelationArgs{
+			Endpoint1: "$deploy-1:db",
+			Endpoint2: "$deploy-3",
+		},
+		GUIArgs:  []interface{}{"$deploy-1:db", "$deploy-3"},
+		Requires: []string{"deploy-1", "deploy-3"},
 	}},
 }, {
 	about: "unit placed in service",
@@ -338,14 +470,21 @@ var fromDataTests = []struct {
                 num_units: 2
                 to: [wordpress]
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/django-42"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:trusty/django-42",
+		},
+		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:trusty/django-42",
+			Service: "django",
+		},
+		GUIArgs: []interface{}{
 			"cs:trusty/django-42",
 			"django",
 			map[string]interface{}{},
@@ -354,41 +493,65 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"wordpress"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "wordpress",
+		},
+		GUIArgs: []interface{}{"wordpress"},
 	}, {
-		Id:     "addService-3",
+		Id:     "deploy-3",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "wordpress",
+			Service: "wordpress",
+		},
+		GUIArgs: []interface{}{
 			"wordpress",
 			"wordpress",
 			map[string]interface{}{},
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
-		Id:       "addUnit-6",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, nil},
-		Requires: []string{"addService-3"},
+		Id:     "addUnit-6",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, nil},
+		Requires: []string{"deploy-3"},
 	}, {
-		Id:       "addUnit-7",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, nil},
-		Requires: []string{"addService-3"},
+		Id:     "addUnit-7",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, nil},
+		Requires: []string{"deploy-3"},
 	}, {
-		Id:       "addUnit-8",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, nil},
-		Requires: []string{"addService-3"},
+		Id:     "addUnit-8",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, nil},
+		Requires: []string{"deploy-3"},
 	}, {
-		Id:       "addUnit-4",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addUnit-6"},
-		Requires: []string{"addService-1", "addUnit-6"},
+		Id:     "addUnit-4",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addUnit-6",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addUnit-6"},
+		Requires: []string{"deploy-1", "addUnit-6"},
 	}, {
-		Id:       "addUnit-5",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addUnit-7"},
-		Requires: []string{"addService-1", "addUnit-7"},
+		Id:     "addUnit-5",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addUnit-7",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addUnit-7"},
+		Requires: []string{"deploy-1", "addUnit-7"},
 	}},
 }, {
 	about: "unit co-location with other units",
@@ -416,14 +579,21 @@ var fromDataTests = []struct {
             1:
                 series: trusty
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/django-42"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:trusty/django-42",
+		},
+		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:trusty/django-42",
+			Service: "django",
+		},
+		GUIArgs: []interface{}{
 			"cs:trusty/django-42",
 			"django",
 			map[string]interface{}{},
@@ -432,11 +602,18 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/mem-47"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:trusty/mem-47",
+		},
+		GUIArgs: []interface{}{"cs:trusty/mem-47"},
 	}, {
-		Id:     "addService-3",
+		Id:     "deploy-3",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:trusty/mem-47",
+			Service: "memcached",
+		},
+		GUIArgs: []interface{}{
 			"cs:trusty/mem-47",
 			"memcached",
 			map[string]interface{}{},
@@ -445,11 +622,18 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-4",
 		Method: "addCharm",
-		Args:   []interface{}{"vivid/rails"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "vivid/rails",
+		},
+		GUIArgs: []interface{}{"vivid/rails"},
 	}, {
-		Id:     "addService-5",
+		Id:     "deploy-5",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "vivid/rails",
+			Service: "ror",
+		},
+		GUIArgs: []interface{}{
 			"vivid/rails",
 			"ror",
 			map[string]interface{}{},
@@ -458,101 +642,182 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-6",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"series":      "trusty",
-			"constraints": "",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			Series: "trusty",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				Series:      "trusty",
+				Constraints: "",
+			},
+		},
 	}, {
-		Id:       "addUnit-12",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, "$addMachines-6"},
-		Requires: []string{"addService-3", "addMachines-6"},
+		Id:     "addUnit-12",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+			To:      "$addMachines-6",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, "$addMachines-6"},
+		Requires: []string{"deploy-3", "addMachines-6"},
 	}, {
-		Id:       "addUnit-16",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-5", 1, "$addMachines-6"},
-		Requires: []string{"addService-5", "addMachines-6"},
+		Id:     "addUnit-16",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-5",
+			To:      "$addMachines-6",
+		},
+		GUIArgs:  []interface{}{"$deploy-5", 1, "$addMachines-6"},
+		Requires: []string{"deploy-5", "addMachines-6"},
 	}, {
 		Id:     "addMachines-20",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"containerType": "kvm",
-			"parentId":      "$addUnit-16",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "kvm",
+			ParentId:      "$addUnit-16",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "kvm",
+				ParentId:      "$addUnit-16",
+			},
+		},
 		Requires: []string{"addUnit-16"},
 	}, {
 		Id:     "addMachines-21",
 		Method: "addMachines",
+		Args:   bundlechanges.AddMachineArgs{},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{},
+		},
 	}, {
 		Id:     "addMachines-22",
 		Method: "addMachines",
+		Args:   bundlechanges.AddMachineArgs{},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{},
+		},
 	}, {
 		Id:     "addMachines-23",
 		Method: "addMachines",
+		Args:   bundlechanges.AddMachineArgs{},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{},
+		},
 	}, {
-		Id:       "addUnit-7",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addUnit-12"},
-		Requires: []string{"addService-1", "addUnit-12"},
+		Id:     "addUnit-7",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addUnit-12",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addUnit-12"},
+		Requires: []string{"deploy-1", "addUnit-12"},
 	}, {
-		Id:       "addUnit-11",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-20"},
-		Requires: []string{"addService-1", "addMachines-20"},
+		Id:     "addUnit-11",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-20",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-20"},
+		Requires: []string{"deploy-1", "addMachines-20"},
 	}, {
-		Id:       "addUnit-13",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, "$addMachines-21"},
-		Requires: []string{"addService-3", "addMachines-21"},
+		Id:     "addUnit-13",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+			To:      "$addMachines-21",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, "$addMachines-21"},
+		Requires: []string{"deploy-3", "addMachines-21"},
 	}, {
-		Id:       "addUnit-14",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-3", 1, "$addMachines-22"},
-		Requires: []string{"addService-3", "addMachines-22"},
+		Id:     "addUnit-14",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-3",
+			To:      "$addMachines-22",
+		},
+		GUIArgs:  []interface{}{"$deploy-3", 1, "$addMachines-22"},
+		Requires: []string{"deploy-3", "addMachines-22"},
 	}, {
-		Id:       "addUnit-15",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-5", 1, "$addMachines-23"},
-		Requires: []string{"addService-5", "addMachines-23"},
+		Id:     "addUnit-15",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-5",
+			To:      "$addMachines-23",
+		},
+		GUIArgs:  []interface{}{"$deploy-5", 1, "$addMachines-23"},
+		Requires: []string{"deploy-5", "addMachines-23"},
 	}, {
 		Id:     "addMachines-17",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"containerType": "lxc",
-			"parentId":      "$addUnit-13",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "lxc",
+			ParentId:      "$addUnit-13",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "lxc",
+				ParentId:      "$addUnit-13",
+			},
+		},
 		Requires: []string{"addUnit-13"},
 	}, {
 		Id:     "addMachines-18",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"containerType": "lxc",
-			"parentId":      "$addUnit-14",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "lxc",
+			ParentId:      "$addUnit-14",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "lxc",
+				ParentId:      "$addUnit-14",
+			},
+		},
 		Requires: []string{"addUnit-14"},
 	}, {
 		Id:     "addMachines-19",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"containerType": "kvm",
-			"parentId":      "$addUnit-15",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "kvm",
+			ParentId:      "$addUnit-15",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "kvm",
+				ParentId:      "$addUnit-15",
+			},
+		},
 		Requires: []string{"addUnit-15"},
 	}, {
-		Id:       "addUnit-8",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-17"},
-		Requires: []string{"addService-1", "addMachines-17"},
+		Id:     "addUnit-8",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-17",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-17"},
+		Requires: []string{"deploy-1", "addMachines-17"},
 	}, {
-		Id:       "addUnit-9",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-18"},
-		Requires: []string{"addService-1", "addMachines-18"},
+		Id:     "addUnit-9",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-18",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-18"},
+		Requires: []string{"deploy-1", "addMachines-18"},
 	}, {
-		Id:       "addUnit-10",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-19"},
-		Requires: []string{"addService-1", "addMachines-19"},
+		Id:     "addUnit-10",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-19",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-19"},
+		Requires: []string{"deploy-1", "addMachines-19"},
 	}},
 }, {
 	about: "unit placed to machines",
@@ -572,14 +837,21 @@ var fromDataTests = []struct {
             8:
                 constraints: "cpu-cores=8"
     `,
-	expected: []*bundlechanges.Change{{
+	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args:   []interface{}{"cs:trusty/django-42"},
+		Args: bundlechanges.AddCharmArgs{
+			Charm: "cs:trusty/django-42",
+		},
+		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
-		Id:     "addService-1",
+		Id:     "deploy-1",
 		Method: "deploy",
-		Args: []interface{}{
+		Args: bundlechanges.AddServiceArgs{
+			Charm:   "cs:trusty/django-42",
+			Service: "django",
+		},
+		GUIArgs: []interface{}{
 			"cs:trusty/django-42",
 			"django",
 			map[string]interface{}{},
@@ -588,61 +860,113 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-2",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"series":      "",
-			"constraints": "cpu-cores=4",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			Constraints: "cpu-cores=4",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				Constraints: "cpu-cores=4",
+			},
+		},
 	}, {
 		Id:     "addMachines-3",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"series":      "",
-			"constraints": "cpu-cores=8",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			Constraints: "cpu-cores=8",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				Constraints: "cpu-cores=8",
+			},
+		},
 	}, {
-		Id:       "addUnit-5",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-2"},
-		Requires: []string{"addService-1", "addMachines-2"},
+		Id:     "addUnit-5",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-2",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-2"},
+		Requires: []string{"deploy-1", "addMachines-2"},
 	}, {
 		Id:     "addMachines-9",
 		Method: "addMachines",
+		Args:   bundlechanges.AddMachineArgs{},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{},
+		},
 	}, {
 		Id:     "addMachines-10",
 		Method: "addMachines",
-		Args: []interface{}{map[string]string{
-			"containerType": "kvm",
-			"parentId":      "$addMachines-3",
-		}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "kvm",
+			ParentId:      "$addMachines-3",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "kvm",
+				ParentId:      "$addMachines-3",
+			},
+		},
 		Requires: []string{"addMachines-3"},
 	}, {
 		Id:     "addMachines-11",
 		Method: "addMachines",
-		Args:   []interface{}{map[string]string{"containerType": "lxc"}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "lxc",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "lxc",
+			},
+		},
 	}, {
 		Id:     "addMachines-12",
 		Method: "addMachines",
-		Args:   []interface{}{map[string]string{"containerType": "lxc"}},
+		Args: bundlechanges.AddMachineArgs{
+			ContainerType: "lxc",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				ContainerType: "lxc",
+			},
+		},
 	}, {
-		Id:       "addUnit-4",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-9"},
-		Requires: []string{"addService-1", "addMachines-9"},
+		Id:     "addUnit-4",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-9",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-9"},
+		Requires: []string{"deploy-1", "addMachines-9"},
 	}, {
-		Id:       "addUnit-6",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-10"},
-		Requires: []string{"addService-1", "addMachines-10"},
+		Id:     "addUnit-6",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-10",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-10"},
+		Requires: []string{"deploy-1", "addMachines-10"},
 	}, {
-		Id:       "addUnit-7",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-11"},
-		Requires: []string{"addService-1", "addMachines-11"},
+		Id:     "addUnit-7",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-11",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-11"},
+		Requires: []string{"deploy-1", "addMachines-11"},
 	}, {
-		Id:       "addUnit-8",
-		Method:   "addUnit",
-		Args:     []interface{}{"$addService-1", 1, "$addMachines-12"},
-		Requires: []string{"addService-1", "addMachines-12"},
+		Id:     "addUnit-8",
+		Method: "addUnit",
+		Args: bundlechanges.AddUnitArgs{
+			Service: "$deploy-1",
+			To:      "$addMachines-12",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", 1, "$addMachines-12"},
+		Requires: []string{"deploy-1", "addMachines-12"},
 	}},
 }}
 
@@ -656,11 +980,49 @@ func (s *changesSuite) TestFromData(c *gc.C) {
 		err = data.Verify(nil)
 		c.Assert(err, jc.ErrorIsNil)
 
-		// Check that the changes are what we expect.
+		// Retrieve the changes, and convert them to a sequence of records.
 		changes := bundlechanges.FromData(data)
-		b, err := json.MarshalIndent(changes, "", "  ")
+		records := make([]record, len(changes))
+		for i, change := range changes {
+			r := record{
+				Id:       change.Id(),
+				Requires: change.Requires(),
+				Method:   change.Method(),
+				GUIArgs:  change.GUIArgs(),
+			}
+			switch change := change.(type) {
+			case *bundlechanges.AddCharmChange:
+				r.Args = change.Args
+			case *bundlechanges.AddMachineChange:
+				r.Args = change.Args
+			case *bundlechanges.AddRelationChange:
+				r.Args = change.Args
+			case *bundlechanges.AddServiceChange:
+				r.Args = change.Args
+			case *bundlechanges.AddUnitChange:
+				r.Args = change.Args
+			case *bundlechanges.SetAnnotationsChange:
+				r.Args = change.Args
+			default:
+				c.Fatalf("unsupported change type %T", change)
+			}
+			records[i] = r
+		}
+
+		// Output the records for debugging.
+		b, err := json.MarshalIndent(records, "", "  ")
 		c.Assert(err, jc.ErrorIsNil)
-		c.Logf("obtained changes: %s", b)
-		c.Assert(changes, jc.DeepEquals, test.expected)
+		c.Logf("obtained records: %s", b)
+
+		// Check that the obtained records are what we expect.
+		c.Assert(records, jc.DeepEquals, test.expected)
 	}
+}
+
+type record struct {
+	Id       string
+	Requires []string
+	Method   string
+	Args     interface{}
+	GUIArgs  []interface{}
 }

--- a/changes_test.go
+++ b/changes_test.go
@@ -5,6 +5,7 @@ package bundlechanges_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -21,6 +22,15 @@ var _ = gc.Suite(&changesSuite{})
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+// record holds expected information about the contents of a change value.
+type record struct {
+	Id       string
+	Requires []string
+	Method   string
+	Params   interface{}
+	GUIArgs  []interface{}
 }
 
 var fromDataTests = []struct {
@@ -40,14 +50,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "django",
 		},
 		GUIArgs: []interface{}{"django"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "django",
 			Service: "django",
 		},
@@ -81,14 +91,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:precise/mediawiki-10",
 		},
 		GUIArgs: []interface{}{"cs:precise/mediawiki-10"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:precise/mediawiki-10",
 			Service: "mediawiki",
 			Options: map[string]interface{}{"debug": false}},
@@ -101,7 +111,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "setAnnotations-2",
 		Method: "setAnnotations",
-		Args: bundlechanges.SetAnnotationsArgs{
+		Params: bundlechanges.SetAnnotationsParams{
 			Id:          "$deploy-1",
 			EntityType:  "service",
 			Annotations: map[string]string{"gui-x": "609", "gui-y": "-15"},
@@ -115,14 +125,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-3",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:precise/mysql-28",
 		},
 		GUIArgs: []interface{}{"cs:precise/mysql-28"},
 	}, {
 		Id:     "deploy-4",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:precise/mysql-28",
 			Service: "mysql",
 		},
@@ -135,7 +145,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addRelation-5",
 		Method: "addRelation",
-		Args: bundlechanges.AddRelationArgs{
+		Params: bundlechanges.AddRelationParams{
 			Endpoint1: "$deploy-1:db",
 			Endpoint2: "$deploy-4:db",
 		},
@@ -144,7 +154,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-6",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 		},
 		GUIArgs:  []interface{}{"$deploy-1", 1, nil},
@@ -152,7 +162,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-7",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-4",
 		},
 		GUIArgs:  []interface{}{"$deploy-4", 1, nil},
@@ -185,14 +195,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:trusty/django-42",
 		},
 		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:trusty/django-42",
 			Service: "django",
 		},
@@ -205,14 +215,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:trusty/haproxy-47",
 		},
 		GUIArgs: []interface{}{"cs:trusty/haproxy-47"},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:trusty/haproxy-47",
 			Service: "haproxy",
 			Options: map[string]interface{}{"bad": "wolf", "number": 42.47},
@@ -226,7 +236,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-4",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			Series: "trusty",
 		},
 		GUIArgs: []interface{}{
@@ -235,14 +245,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-5",
 		Method: "addMachines",
-		Args:   bundlechanges.AddMachineArgs{},
+		Params: bundlechanges.AddMachineParams{},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{},
 		},
 	}, {
 		Id:     "addUnit-6",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-4",
 		},
@@ -251,7 +261,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-10",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "lxc",
 			ParentId:      "$addMachines-5",
 		},
@@ -265,7 +275,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-11",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "lxc",
 			ParentId:      "$addUnit-6",
 		},
@@ -279,14 +289,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-12",
 		Method: "addMachines",
-		Args:   bundlechanges.AddMachineArgs{},
+		Params: bundlechanges.AddMachineParams{},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{},
 		},
 	}, {
 		Id:     "addUnit-7",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-10",
 		},
@@ -295,7 +305,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-8",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 			To:      "$addMachines-11",
 		},
@@ -304,7 +314,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-9",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 			To:      "$addMachines-12",
 		},
@@ -330,14 +340,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:trusty/django-42",
 		},
 		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:trusty/django-42",
 			Service: "django",
 		},
@@ -350,7 +360,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-2",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			Constraints: "cpu-cores=4",
 		},
 		GUIArgs: []interface{}{
@@ -359,7 +369,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "setAnnotations-3",
 		Method: "setAnnotations",
-		Args: bundlechanges.SetAnnotationsArgs{
+		Params: bundlechanges.SetAnnotationsParams{
 			Id:          "$addMachines-2",
 			EntityType:  "machine",
 			Annotations: map[string]string{"foo": "bar"},
@@ -373,7 +383,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-4",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-2",
 		},
@@ -382,14 +392,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-6",
 		Method: "addMachines",
-		Args:   bundlechanges.AddMachineArgs{},
+		Params: bundlechanges.AddMachineParams{},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{},
 		},
 	}, {
 		Id:     "addUnit-5",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-6",
 		},
@@ -411,14 +421,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:precise/mediawiki-10",
 		},
 		GUIArgs: []interface{}{"cs:precise/mediawiki-10"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:precise/mediawiki-10",
 			Service: "mediawiki",
 		},
@@ -431,14 +441,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:precise/mysql-28",
 		},
 		GUIArgs: []interface{}{"cs:precise/mysql-28"},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:precise/mysql-28",
 			Service: "mysql",
 		},
@@ -451,7 +461,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addRelation-4",
 		Method: "addRelation",
-		Args: bundlechanges.AddRelationArgs{
+		Params: bundlechanges.AddRelationParams{
 			Endpoint1: "$deploy-1:db",
 			Endpoint2: "$deploy-3",
 		},
@@ -473,14 +483,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:trusty/django-42",
 		},
 		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:trusty/django-42",
 			Service: "django",
 		},
@@ -493,14 +503,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "wordpress",
 		},
 		GUIArgs: []interface{}{"wordpress"},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "wordpress",
 			Service: "wordpress",
 		},
@@ -513,7 +523,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-6",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 		},
 		GUIArgs:  []interface{}{"$deploy-3", 1, nil},
@@ -521,7 +531,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-7",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 		},
 		GUIArgs:  []interface{}{"$deploy-3", 1, nil},
@@ -529,7 +539,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-8",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 		},
 		GUIArgs:  []interface{}{"$deploy-3", 1, nil},
@@ -537,7 +547,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-4",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addUnit-6",
 		},
@@ -546,7 +556,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-5",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addUnit-7",
 		},
@@ -582,14 +592,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:trusty/django-42",
 		},
 		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:trusty/django-42",
 			Service: "django",
 		},
@@ -602,14 +612,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:trusty/mem-47",
 		},
 		GUIArgs: []interface{}{"cs:trusty/mem-47"},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:trusty/mem-47",
 			Service: "memcached",
 		},
@@ -622,14 +632,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addCharm-4",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "vivid/rails",
 		},
 		GUIArgs: []interface{}{"vivid/rails"},
 	}, {
 		Id:     "deploy-5",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "vivid/rails",
 			Service: "ror",
 		},
@@ -642,7 +652,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-6",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			Series: "trusty",
 		},
 		GUIArgs: []interface{}{
@@ -654,7 +664,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-12",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 			To:      "$addMachines-6",
 		},
@@ -663,7 +673,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-16",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-5",
 			To:      "$addMachines-6",
 		},
@@ -672,7 +682,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-20",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "kvm",
 			ParentId:      "$addUnit-16",
 		},
@@ -686,28 +696,28 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-21",
 		Method: "addMachines",
-		Args:   bundlechanges.AddMachineArgs{},
+		Params: bundlechanges.AddMachineParams{},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{},
 		},
 	}, {
 		Id:     "addMachines-22",
 		Method: "addMachines",
-		Args:   bundlechanges.AddMachineArgs{},
+		Params: bundlechanges.AddMachineParams{},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{},
 		},
 	}, {
 		Id:     "addMachines-23",
 		Method: "addMachines",
-		Args:   bundlechanges.AddMachineArgs{},
+		Params: bundlechanges.AddMachineParams{},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{},
 		},
 	}, {
 		Id:     "addUnit-7",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addUnit-12",
 		},
@@ -716,7 +726,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-11",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-20",
 		},
@@ -725,7 +735,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-13",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 			To:      "$addMachines-21",
 		},
@@ -734,7 +744,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-14",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-3",
 			To:      "$addMachines-22",
 		},
@@ -743,7 +753,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-15",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-5",
 			To:      "$addMachines-23",
 		},
@@ -752,7 +762,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-17",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "lxc",
 			ParentId:      "$addUnit-13",
 		},
@@ -766,7 +776,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-18",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "lxc",
 			ParentId:      "$addUnit-14",
 		},
@@ -780,7 +790,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-19",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "kvm",
 			ParentId:      "$addUnit-15",
 		},
@@ -794,7 +804,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-8",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-17",
 		},
@@ -803,7 +813,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-9",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-18",
 		},
@@ -812,7 +822,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-10",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-19",
 		},
@@ -840,14 +850,14 @@ var fromDataTests = []struct {
 	expected: []record{{
 		Id:     "addCharm-0",
 		Method: "addCharm",
-		Args: bundlechanges.AddCharmArgs{
+		Params: bundlechanges.AddCharmParams{
 			Charm: "cs:trusty/django-42",
 		},
 		GUIArgs: []interface{}{"cs:trusty/django-42"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
-		Args: bundlechanges.AddServiceArgs{
+		Params: bundlechanges.AddServiceParams{
 			Charm:   "cs:trusty/django-42",
 			Service: "django",
 		},
@@ -860,7 +870,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-2",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			Constraints: "cpu-cores=4",
 		},
 		GUIArgs: []interface{}{
@@ -871,7 +881,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-3",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			Constraints: "cpu-cores=8",
 		},
 		GUIArgs: []interface{}{
@@ -882,7 +892,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-5",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-2",
 		},
@@ -891,14 +901,14 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-9",
 		Method: "addMachines",
-		Args:   bundlechanges.AddMachineArgs{},
+		Params: bundlechanges.AddMachineParams{},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{},
 		},
 	}, {
 		Id:     "addMachines-10",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "kvm",
 			ParentId:      "$addMachines-3",
 		},
@@ -912,7 +922,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-11",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "lxc",
 		},
 		GUIArgs: []interface{}{
@@ -923,7 +933,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addMachines-12",
 		Method: "addMachines",
-		Args: bundlechanges.AddMachineArgs{
+		Params: bundlechanges.AddMachineParams{
 			ContainerType: "lxc",
 		},
 		GUIArgs: []interface{}{
@@ -934,7 +944,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-4",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-9",
 		},
@@ -943,7 +953,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-6",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-10",
 		},
@@ -952,7 +962,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-7",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-11",
 		},
@@ -961,7 +971,7 @@ var fromDataTests = []struct {
 	}, {
 		Id:     "addUnit-8",
 		Method: "addUnit",
-		Args: bundlechanges.AddUnitArgs{
+		Params: bundlechanges.AddUnitParams{
 			Service: "$deploy-1",
 			To:      "$addMachines-12",
 		},
@@ -990,22 +1000,7 @@ func (s *changesSuite) TestFromData(c *gc.C) {
 				Method:   change.Method(),
 				GUIArgs:  change.GUIArgs(),
 			}
-			switch change := change.(type) {
-			case *bundlechanges.AddCharmChange:
-				r.Args = change.Args
-			case *bundlechanges.AddMachineChange:
-				r.Args = change.Args
-			case *bundlechanges.AddRelationChange:
-				r.Args = change.Args
-			case *bundlechanges.AddServiceChange:
-				r.Args = change.Args
-			case *bundlechanges.AddUnitChange:
-				r.Args = change.Args
-			case *bundlechanges.SetAnnotationsChange:
-				r.Args = change.Args
-			default:
-				c.Fatalf("unsupported change type %T", change)
-			}
+			r.Params = reflect.ValueOf(change).Elem().FieldByName("Params").Interface()
 			records[i] = r
 		}
 
@@ -1017,12 +1012,4 @@ func (s *changesSuite) TestFromData(c *gc.C) {
 		// Check that the obtained records are what we expect.
 		c.Assert(records, jc.DeepEquals, test.expected)
 	}
-}
-
-type record struct {
-	Id       string
-	Requires []string
-	Method   string
-	Args     interface{}
-	GUIArgs  []interface{}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -28,7 +28,7 @@ func handleServices(add func(Change), services map[string]*charm.ServiceSpec) ma
 		service := services[name]
 		// Add the addCharm record if one hasn't been added yet.
 		if charms[service.Charm] == "" {
-			change = newAddCharmChange(AddCharmArgs{
+			change = newAddCharmChange(AddCharmParams{
 				Charm: service.Charm,
 			})
 			add(change)
@@ -36,7 +36,7 @@ func handleServices(add func(Change), services map[string]*charm.ServiceSpec) ma
 		}
 
 		// Add the addService record for this service.
-		change = newAddServiceChange(AddServiceArgs{
+		change = newAddServiceChange(AddServiceParams{
 			Charm:   service.Charm,
 			Service: name,
 			Options: service.Options,
@@ -46,7 +46,7 @@ func handleServices(add func(Change), services map[string]*charm.ServiceSpec) ma
 
 		// Add service annotations.
 		if len(service.Annotations) > 0 {
-			add(newSetAnnotationsChange(SetAnnotationsArgs{
+			add(newSetAnnotationsChange(SetAnnotationsParams{
 				EntityType:  "service",
 				Id:          "$" + change.Id(),
 				Annotations: service.Annotations,
@@ -74,7 +74,7 @@ func handleMachines(add func(Change), machines map[string]*charm.MachineSpec) ma
 			machine = &charm.MachineSpec{}
 		}
 		// Add the addMachines record for this machine.
-		change = newAddMachineChange(AddMachineArgs{
+		change = newAddMachineChange(AddMachineParams{
 			Series:      machine.Series,
 			Constraints: machine.Constraints,
 		})
@@ -83,7 +83,7 @@ func handleMachines(add func(Change), machines map[string]*charm.MachineSpec) ma
 
 		// Add machine annotations.
 		if len(machine.Annotations) > 0 {
-			add(newSetAnnotationsChange(SetAnnotationsArgs{
+			add(newSetAnnotationsChange(SetAnnotationsParams{
 				EntityType:  "machine",
 				Id:          "$" + change.Id(),
 				Annotations: machine.Annotations,
@@ -106,7 +106,7 @@ func handleRelations(add func(Change), relations [][]string, addedServices map[s
 			ep.service = service
 			args[i] = "$" + ep.String()
 		}
-		add(newAddRelationChange(AddRelationArgs{
+		add(newAddRelationChange(AddRelationParams{
 			Endpoint1: args[0],
 			Endpoint2: args[1],
 		}, requires...))
@@ -130,7 +130,7 @@ func handleUnits(add func(Change), services map[string]*charm.ServiceSpec, added
 		service := services[name]
 		for i := 0; i < service.NumUnits; i++ {
 			addedService := addedServices[name]
-			change := newAddUnitChange(AddUnitArgs{
+			change := newAddUnitChange(AddUnitParams{
 				Service: "$" + addedService,
 			}, addedService)
 			add(change)
@@ -166,7 +166,7 @@ func handleUnits(add func(Change), services map[string]*charm.ServiceSpec, added
 			// new parent requirement and placement target.
 			change := records[fmt.Sprintf("%s/%d", name, i)]
 			change.requires = append(change.requires, parentId)
-			change.Args.To = "$" + parentId
+			change.Params.To = "$" + parentId
 		}
 	}
 }
@@ -179,7 +179,7 @@ func unitParent(add func(Change), p string, records map[string]*AddUnitChange, a
 	}
 	if placement.Machine == "new" {
 		// The unit is placed to a new machine.
-		change := newAddMachineChange(AddMachineArgs{
+		change := newAddMachineChange(AddMachineParams{
 			ContainerType: placement.ContainerType,
 		})
 		add(change)
@@ -214,7 +214,7 @@ func unitParent(add func(Change), p string, records map[string]*AddUnitChange, a
 }
 
 func addContainer(add func(Change), containerType, parentId string) string {
-	change := newAddMachineChange(AddMachineArgs{
+	change := newAddMachineChange(AddMachineParams{
 		ContainerType: containerType,
 		ParentId:      "$" + parentId,
 	}, parentId)

--- a/handlers.go
+++ b/handlers.go
@@ -11,13 +11,9 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 )
 
-// addChangeFunc is used to add a change to a change set. The resulting change
-// is also returned.
-type addChangeFunc func(method string, requires []string, args ...interface{}) *Change
-
 // handleServices populates the change set with "addCharm"/"addService" records.
 // This function also handles adding service annotations.
-func handleServices(add addChangeFunc, services map[string]*charm.ServiceSpec) map[string]string {
+func handleServices(add func(Change), services map[string]*charm.ServiceSpec) map[string]string {
 	charms := make(map[string]string, len(services))
 	addedServices := make(map[string]string, len(services))
 	// Iterate over the map using its sorted keys so that results are
@@ -27,25 +23,34 @@ func handleServices(add addChangeFunc, services map[string]*charm.ServiceSpec) m
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	var change Change
 	for _, name := range names {
 		service := services[name]
 		// Add the addCharm record if one hasn't been added yet.
 		if charms[service.Charm] == "" {
-			change := add("addCharm", nil, service.Charm)
-			charms[service.Charm] = change.Id
+			change = newAddCharmChange(AddCharmArgs{
+				Charm: service.Charm,
+			})
+			add(change)
+			charms[service.Charm] = change.Id()
 		}
 
 		// Add the addService record for this service.
-		options := service.Options
-		if options == nil {
-			options = make(map[string]interface{}, 0)
-		}
-		change := add("deploy", []string{charms[service.Charm]}, service.Charm, name, options)
-		addedServices[name] = change.Id
+		change = newAddServiceChange(AddServiceArgs{
+			Charm:   service.Charm,
+			Service: name,
+			Options: service.Options,
+		}, charms[service.Charm])
+		add(change)
+		addedServices[name] = change.Id()
 
 		// Add service annotations.
 		if len(service.Annotations) > 0 {
-			add("setAnnotations", []string{change.Id}, "$"+change.Id, "service", service.Annotations)
+			add(newSetAnnotationsChange(SetAnnotationsArgs{
+				EntityType:  "service",
+				Id:          "$" + change.Id(),
+				Annotations: service.Annotations,
+			}, change.Id()))
 		}
 	}
 	return addedServices
@@ -53,7 +58,7 @@ func handleServices(add addChangeFunc, services map[string]*charm.ServiceSpec) m
 
 // handleMachines populates the change set with "addMachines" records.
 // This function also handles adding machine annotations.
-func handleMachines(add addChangeFunc, machines map[string]*charm.MachineSpec) map[string]string {
+func handleMachines(add func(Change), machines map[string]*charm.MachineSpec) map[string]string {
 	addedMachines := make(map[string]string, len(machines))
 	// Iterate over the map using its sorted keys so that results are
 	// deterministic and easier to test.
@@ -62,31 +67,37 @@ func handleMachines(add addChangeFunc, machines map[string]*charm.MachineSpec) m
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	var change Change
 	for _, name := range names {
 		machine := machines[name]
 		if machine == nil {
 			machine = &charm.MachineSpec{}
 		}
 		// Add the addMachines record for this machine.
-		change := add("addMachines", nil, map[string]string{
-			"series":      machine.Series,
-			"constraints": machine.Constraints,
+		change = newAddMachineChange(AddMachineArgs{
+			Series:      machine.Series,
+			Constraints: machine.Constraints,
 		})
-		addedMachines[name] = change.Id
+		add(change)
+		addedMachines[name] = change.Id()
 
 		// Add machine annotations.
 		if len(machine.Annotations) > 0 {
-			add("setAnnotations", []string{change.Id}, "$"+change.Id, "machine", machine.Annotations)
+			add(newSetAnnotationsChange(SetAnnotationsArgs{
+				EntityType:  "machine",
+				Id:          "$" + change.Id(),
+				Annotations: machine.Annotations,
+			}, change.Id()))
 		}
 	}
 	return addedMachines
 }
 
 // handleRelations populates the change set with "addRelation" records.
-func handleRelations(add addChangeFunc, relations [][]string, addedServices map[string]string) {
+func handleRelations(add func(Change), relations [][]string, addedServices map[string]string) {
 	for _, relation := range relations {
 		// Add the addRelation record for this relation pair.
-		args := make([]interface{}, 2)
+		args := make([]string, 2)
 		requires := make([]string, 2)
 		for i, endpoint := range relation {
 			ep := parseEndpoint(endpoint)
@@ -95,14 +106,17 @@ func handleRelations(add addChangeFunc, relations [][]string, addedServices map[
 			ep.service = service
 			args[i] = "$" + ep.String()
 		}
-		add("addRelation", requires, args...)
+		add(newAddRelationChange(AddRelationArgs{
+			Endpoint1: args[0],
+			Endpoint2: args[1],
+		}, requires...))
 	}
 }
 
 // handleUnits populates the change set with "addUnit" records.
 // It also handles adding machine containers where to place units if required.
-func handleUnits(add addChangeFunc, services map[string]*charm.ServiceSpec, addedServices, addedMachines map[string]string) {
-	records := make(map[string]*Change)
+func handleUnits(add func(Change), services map[string]*charm.ServiceSpec, addedServices, addedMachines map[string]string) {
+	records := make(map[string]*AddUnitChange)
 	// Iterate over the map using its sorted keys so that results are
 	// deterministic and easier to test.
 	names := make([]string, 0, len(services))
@@ -116,7 +130,10 @@ func handleUnits(add addChangeFunc, services map[string]*charm.ServiceSpec, adde
 		service := services[name]
 		for i := 0; i < service.NumUnits; i++ {
 			addedService := addedServices[name]
-			change := add("addUnit", []string{addedService}, "$"+addedService, 1, nil)
+			change := newAddUnitChange(AddUnitArgs{
+				Service: "$" + addedService,
+			}, addedService)
+			add(change)
 			records[fmt.Sprintf("%s/%d", name, i)] = change
 		}
 	}
@@ -148,13 +165,13 @@ func handleUnits(add addChangeFunc, services map[string]*charm.ServiceSpec, adde
 			// Retrieve and modify the original "addUnit" change to add the
 			// new parent requirement and placement target.
 			change := records[fmt.Sprintf("%s/%d", name, i)]
-			change.Requires = append(change.Requires, parentId)
-			change.Args[2] = "$" + parentId
+			change.requires = append(change.requires, parentId)
+			change.Args.To = "$" + parentId
 		}
 	}
 }
 
-func unitParent(add addChangeFunc, p string, records map[string]*Change, addedMachines map[string]string, servicePlacedUnits map[string]int) (parentId string) {
+func unitParent(add func(Change), p string, records map[string]*AddUnitChange, addedMachines map[string]string, servicePlacedUnits map[string]int) (parentId string) {
 	placement, err := charm.ParsePlacement(p)
 	if err != nil {
 		// Since the bundle is already verified, this should never happen.
@@ -162,13 +179,11 @@ func unitParent(add addChangeFunc, p string, records map[string]*Change, addedMa
 	}
 	if placement.Machine == "new" {
 		// The unit is placed to a new machine.
-		var args []interface{}
-		if placement.ContainerType != "" {
-			args = []interface{}{
-				map[string]string{"containerType": placement.ContainerType},
-			}
-		}
-		return add("addMachines", nil, args...).Id
+		change := newAddMachineChange(AddMachineArgs{
+			ContainerType: placement.ContainerType,
+		})
+		add(change)
+		return change.Id()
 	}
 	if placement.Machine != "" {
 		// The unit is placed to a machine declared in the bundle.
@@ -191,19 +206,20 @@ func unitParent(add addChangeFunc, p string, records map[string]*Change, addedMa
 		servicePlacedUnits[placement.Service] = number
 	}
 	otherUnit := fmt.Sprintf("%s/%d", placement.Service, number)
-	parentId = records[otherUnit].Id
+	parentId = records[otherUnit].Id()
 	if placement.ContainerType != "" {
 		parentId = addContainer(add, placement.ContainerType, parentId)
 	}
 	return parentId
 }
 
-func addContainer(add addChangeFunc, containerType, parentId string) string {
-	change := add("addMachines", []string{parentId}, map[string]string{
-		"containerType": containerType,
-		"parentId":      "$" + parentId,
-	})
-	return change.Id
+func addContainer(add func(Change), containerType, parentId string) string {
+	change := newAddMachineChange(AddMachineArgs{
+		ContainerType: containerType,
+		ParentId:      "$" + parentId,
+	}, parentId)
+	add(change)
+	return change.Id()
 }
 
 // parseEndpoint creates an endpoint from its string representation.


### PR DESCRIPTION
A change is now expressed as an interface.
Avoid using []inteface{} for the arguments.
Define specific types for each change implementation instead.