### PR TITLE
Add Storage to AddServiceParams

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -212,7 +212,11 @@ func (ch *AddServiceChange) GUIArgs() []interface{} {
 	if options == nil {
 		options = make(map[string]interface{}, 0)
 	}
-	return []interface{}{ch.Params.Charm, ch.Params.Service, options, ch.Params.Constraints}
+	storage := ch.Params.Storage
+	if storage == nil {
+		storage = make(map[string]string, 0)
+	}
+	return []interface{}{ch.Params.Charm, ch.Params.Service, options, ch.Params.Constraints, storage}
 }
 
 // AddServiceParams holds parameters for deploying a Juju service.
@@ -225,6 +229,8 @@ type AddServiceParams struct {
 	Options map[string]interface{}
 	// Constraints holds the optional service constraints.
 	Constraints string
+	// Storage holds the optional storage constraints.
+	Storage map[string]string
 }
 
 // newAddUnitChange creates a new change for adding a service unit.

--- a/cmd/get-bundle-changes/main.go
+++ b/cmd/get-bundle-changes/main.go
@@ -54,7 +54,7 @@ func process(r io.Reader, w io.Writer) error {
 		return err
 	}
 	// Validate the bundle.
-	if err := data.Verify(nil); err != nil {
+	if err := data.Verify(nil, nil); err != nil {
 		return err
 	}
 	// Generate the changes and convert them to the standard form.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -9,6 +9,6 @@ github.com/juju/testing	git	f521911d9a79aeb62c051fe18e689796369c5564	2015-05-29T
 github.com/juju/utils	git	6f48322bb574b8578e8ecccf689220eac7edad9d	2015-08-10T03:07:18Z
 golang.org/x/crypto	git	c57d4a71915a248dbad846d60825145062b4c18e	2015-03-27T05:11:19Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
-gopkg.in/juju/charm.v6-unstable	git	f93c81467758d7237af01239ffb3fdad89c3f179	2015-11-04T09:35:00Z
+gopkg.in/juju/charm.v6-unstable	git	a3d228ef5292531219d17d47679b260580fba1a8	2015-11-19T07:39:58Z
 gopkg.in/mgo.v2	git	3569c88678d88179dcbd68d02ab081cbca3cd4d0	2015-06-04T15:26:27Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z

--- a/handlers.go
+++ b/handlers.go
@@ -41,6 +41,7 @@ func handleServices(add func(Change), services map[string]*charm.ServiceSpec) ma
 			Service:     name,
 			Options:     service.Options,
 			Constraints: service.Constraints,
+			Storage:     service.Storage,
 		}, charms[service.Charm])
 		add(change)
 		id := change.Id()


### PR DESCRIPTION
Add support for storage constraints to bundle changes.
This will be used by juju/juju to deploy bundles with
services that require storage.

Storage constraints are being added to GUI arguments;
I'm not sure if this will have any negative effects,
or if extraneous arguments are simply ignored. Please
advise.