### PR TITLE
Put application constraints on container addMachine changes

### DIFF
--- a/changes_test.go
+++ b/changes_test.go
@@ -390,12 +390,14 @@ var fromDataTests = []struct {
 			ContainerType: "lxc",
 			Series:        "trusty",
 			ParentId:      "$addMachines-6",
+			Constraints:   "cpu-cores=4 cpu-power=42",
 		},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{
 				ContainerType: "lxc",
 				Series:        "trusty",
 				ParentId:      "$addMachines-6",
+				Constraints:   "cpu-cores=4 cpu-power=42",
 			},
 		},
 		Requires: []string{"addMachines-6"},
@@ -1441,7 +1443,7 @@ func (s *changesSuite) assertParseData(c *gc.C, content string, expected []recor
 	c.Logf("obtained records: %s", b)
 
 	// Check that the obtained records are what we expect.
-	c.Assert(records, jc.DeepEquals, expected)
+	c.Check(records, jc.DeepEquals, expected)
 }
 
 func (s *changesSuite) TestFromData(c *gc.C) {

--- a/changes_test.go
+++ b/changes_test.go
@@ -1213,6 +1213,68 @@ var fromDataTests = []struct {
 		Requires: []string{"deploy-1", "addMachines-12"},
 	}},
 }, {
+	about: "unit placed to new machine with constraints",
+	content: `
+        services:
+            django:
+                charm: cs:trusty/django-42
+                num_units: 1
+                to:
+                    - new
+                constraints: "cpu-cores=4"
+    `,
+	expected: []record{{
+		Id:     "addCharm-0",
+		Method: "addCharm",
+		Params: bundlechanges.AddCharmParams{
+			Charm:  "cs:trusty/django-42",
+			Series: "trusty",
+		},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Params: bundlechanges.AddApplicationParams{
+			Charm:       "$addCharm-0",
+			Application: "django",
+			Series:      "trusty",
+			Constraints: "cpu-cores=4",
+		},
+		GUIArgs: []interface{}{
+			"$addCharm-0",
+			"trusty",
+			"django",
+			map[string]interface{}{},
+			"cpu-cores=4",
+			map[string]string{},
+			map[string]string{},
+			map[string]int{},
+		},
+		Requires: []string{"addCharm-0"},
+	}, {
+		Id:     "addMachines-3",
+		Method: "addMachines",
+		Params: bundlechanges.AddMachineParams{
+			Constraints: "cpu-cores=4",
+			Series:      "trusty",
+		},
+		GUIArgs: []interface{}{
+			bundlechanges.AddMachineOptions{
+				Series:      "trusty",
+				Constraints: "cpu-cores=4",
+			},
+		},
+	}, {
+		Id:     "addUnit-2",
+		Method: "addUnit",
+		Params: bundlechanges.AddUnitParams{
+			Application: "$deploy-1",
+			To:          "$addMachines-3",
+		},
+		GUIArgs:  []interface{}{"$deploy-1", "$addMachines-3"},
+		Requires: []string{"deploy-1", "addMachines-3"},
+	}},
+}, {
 	about: "application with storage",
 	content: `
         services:

--- a/handlers.go
+++ b/handlers.go
@@ -181,7 +181,7 @@ func handleUnits(add func(Change), services map[string]*charm.ApplicationSpec, a
 			}
 			// Generate the changes required in order to place this unit, and
 			// retrieve the identifier of the parent change.
-			parentId := unitParent(add, p, records, addedMachines, servicePlacedUnits, getSeries(application, defaultSeries), application)
+			parentId := unitParent(add, p, records, addedMachines, servicePlacedUnits, getSeries(application, defaultSeries), application.Constraints)
 			// Retrieve and modify the original "addUnit" change to add the
 			// new parent requirement and placement target.
 			change := records[fmt.Sprintf("%s/%d", name, i)]
@@ -191,7 +191,7 @@ func handleUnits(add func(Change), services map[string]*charm.ApplicationSpec, a
 	}
 }
 
-func unitParent(add func(Change), p string, records map[string]*AddUnitChange, addedMachines map[string]string, servicePlacedUnits map[string]int, series string, application *charm.ApplicationSpec) (parentId string) {
+func unitParent(add func(Change), p string, records map[string]*AddUnitChange, addedMachines map[string]string, servicePlacedUnits map[string]int, series string, appConstraints string) (parentId string) {
 	placement, err := charm.ParsePlacement(p)
 	if err != nil {
 		// Since the bundle is already verified, this should never happen.
@@ -202,7 +202,7 @@ func unitParent(add func(Change), p string, records map[string]*AddUnitChange, a
 		change := newAddMachineChange(AddMachineParams{
 			ContainerType: placement.ContainerType,
 			Series:        series,
-			Constraints:   application.Constraints,
+			Constraints:   appConstraints,
 		})
 		add(change)
 		return change.Id()
@@ -211,7 +211,7 @@ func unitParent(add func(Change), p string, records map[string]*AddUnitChange, a
 		// The unit is placed to a machine declared in the bundle.
 		parentId = addedMachines[placement.Machine]
 		if placement.ContainerType != "" {
-			parentId = addContainer(add, placement.ContainerType, parentId, series, application)
+			parentId = addContainer(add, placement.ContainerType, parentId, series, appConstraints)
 		}
 		return parentId
 	}
@@ -230,17 +230,17 @@ func unitParent(add func(Change), p string, records map[string]*AddUnitChange, a
 	otherUnit := fmt.Sprintf("%s/%d", placement.Application, number)
 	parentId = records[otherUnit].Id()
 	if placement.ContainerType != "" {
-		parentId = addContainer(add, placement.ContainerType, parentId, series, application)
+		parentId = addContainer(add, placement.ContainerType, parentId, series, appConstraints)
 	}
 	return parentId
 }
 
-func addContainer(add func(Change), containerType, parentId string, series string, application *charm.ApplicationSpec) string {
+func addContainer(add func(Change), containerType, parentId string, series string, appConstraints string) string {
 	p := AddMachineParams{
 		ContainerType: containerType,
 		ParentId:      "$" + parentId,
 		Series:        series,
-		Constraints:   application.Constraints,
+		Constraints:   appConstraints,
 	}
 	change := newAddMachineChange(p, parentId)
 	add(change)


### PR DESCRIPTION
Fixes bug #1626597 in Juju. Application constraints are added to the add machine changes for containers. 

There was an existing test asserting that this was *not done* as that was the previous specification. This is a specification change, so I have changed the existing test rather than needing to add a new one.