### PR TITLE
Add endpoint spaces to machines constraints

### DIFF
--- a/changes_test.go
+++ b/changes_test.go
@@ -275,12 +275,15 @@ var fromDataTests = []struct {
 		Requires: []string{"deploy-1"},
 	}},
 }, {
-	about: "machines and units placement",
+	about: "machines and units placement, with bindings",
 	content: `
         services:
             django:
                 charm: cs:trusty/django-42
                 num_units: 2
+                bindings:
+                    "": foo
+                    http: bar
                 to:
                     - 1
                     - lxc:2
@@ -312,10 +315,11 @@ var fromDataTests = []struct {
 		Id:     "deploy-1",
 		Method: "deploy",
 		Params: bundlechanges.AddApplicationParams{
-			Charm:       "$addCharm-0",
-			Application: "django",
-			Series:      "trusty",
-			Constraints: "cpu-cores=4 cpu-power=42",
+			Charm:            "$addCharm-0",
+			Application:      "django",
+			Series:           "trusty",
+			Constraints:      "cpu-cores=4 cpu-power=42",
+			EndpointBindings: map[string]string{"": "foo", "http": "bar"},
 		},
 		GUIArgs: []interface{}{
 			"$addCharm-0",
@@ -324,7 +328,7 @@ var fromDataTests = []struct {
 			map[string]interface{}{},
 			"cpu-cores=4 cpu-power=42",
 			map[string]string{},
-			map[string]string{},
+			map[string]string{"": "foo", "http": "bar"},
 			map[string]int{},
 		},
 		Requires: []string{"addCharm-0"},
@@ -396,14 +400,14 @@ var fromDataTests = []struct {
 			ContainerType: "lxc",
 			Series:        "trusty",
 			ParentId:      "$addMachines-6",
-			Constraints:   "cpu-cores=4 cpu-power=42",
+			Constraints:   "spaces=bar,foo cpu-cores=4 cpu-power=42",
 		},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{
 				ContainerType: "lxc",
 				Series:        "trusty",
 				ParentId:      "$addMachines-6",
-				Constraints:   "cpu-cores=4 cpu-power=42",
+				Constraints:   "spaces=bar,foo cpu-cores=4 cpu-power=42",
 			},
 		},
 		Requires: []string{"addMachines-6"},

--- a/changes_test.go
+++ b/changes_test.go
@@ -287,7 +287,7 @@ var fromDataTests = []struct {
                 to:
                     - 1
                     - lxc:2
-                constraints: cpu-cores=4 cpu-power=42
+                constraints: spaces=baz cpu-cores=4 cpu-power=42
             haproxy:
                 charm: cs:trusty/haproxy-47
                 num_units: 2
@@ -318,7 +318,7 @@ var fromDataTests = []struct {
 			Charm:            "$addCharm-0",
 			Application:      "django",
 			Series:           "trusty",
-			Constraints:      "cpu-cores=4 cpu-power=42",
+			Constraints:      "spaces=baz cpu-cores=4 cpu-power=42",
 			EndpointBindings: map[string]string{"": "foo", "http": "bar"},
 		},
 		GUIArgs: []interface{}{
@@ -326,7 +326,7 @@ var fromDataTests = []struct {
 			"trusty",
 			"django",
 			map[string]interface{}{},
-			"cpu-cores=4 cpu-power=42",
+			"spaces=baz cpu-cores=4 cpu-power=42",
 			map[string]string{},
 			map[string]string{"": "foo", "http": "bar"},
 			map[string]int{},
@@ -400,14 +400,14 @@ var fromDataTests = []struct {
 			ContainerType: "lxc",
 			Series:        "trusty",
 			ParentId:      "$addMachines-6",
-			Constraints:   "spaces=bar,foo cpu-cores=4 cpu-power=42",
+			Constraints:   "spaces=bar,baz,foo cpu-cores=4 cpu-power=42",
 		},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{
 				ContainerType: "lxc",
 				Series:        "trusty",
 				ParentId:      "$addMachines-6",
-				Constraints:   "spaces=bar,foo cpu-cores=4 cpu-power=42",
+				Constraints:   "spaces=bar,baz,foo cpu-cores=4 cpu-power=42",
 			},
 		},
 		Requires: []string{"addMachines-6"},


### PR DESCRIPTION
When deploying a large bundle containers can be deployed before units are assigned to them. This might cause them not to have required spaces assigned. This patch fixes it by setting an explicit constraint for spaces on machines deployed for applications. 