### PR TITLE
Sort machines naturally.

### DIFF
--- a/changes_test.go
+++ b/changes_test.go
@@ -2495,6 +2495,59 @@ func (s *changesSuite) TestChangeDescriptions(c *gc.C) {
 				"add unit ror/2 to new machine 3",
 			},
 		}, {
+			description: "machine natural sorting",
+			bundleContent: `
+                applications:
+                    ubu:
+                        charm: cs:ubuntu
+                        num_units: 13
+                        to: [0,1,2,3,4,5,6,7,8,9,10,11,12]
+                machines:
+                    0:
+                    1:
+                    2:
+                    3:
+                    4:
+                    5:
+                    6:
+                    7:
+                    8:
+                    9:
+                    10:
+                    11:
+                    12:
+            `,
+			expectedChanges: []string{
+				"upload charm cs:ubuntu",
+				"deploy application ubu using cs:ubuntu",
+				"add new machine 0",
+				"add new machine 1",
+				"add new machine 2",
+				"add new machine 3",
+				"add new machine 4",
+				"add new machine 5",
+				"add new machine 6",
+				"add new machine 7",
+				"add new machine 8",
+				"add new machine 9",
+				"add new machine 10",
+				"add new machine 11",
+				"add new machine 12",
+				"add unit ubu/0 to new machine 0",
+				"add unit ubu/1 to new machine 1",
+				"add unit ubu/2 to new machine 2",
+				"add unit ubu/3 to new machine 3",
+				"add unit ubu/4 to new machine 4",
+				"add unit ubu/5 to new machine 5",
+				"add unit ubu/6 to new machine 6",
+				"add unit ubu/7 to new machine 7",
+				"add unit ubu/8 to new machine 8",
+				"add unit ubu/9 to new machine 9",
+				"add unit ubu/10 to new machine 10",
+				"add unit ubu/11 to new machine 11",
+				"add unit ubu/12 to new machine 12",
+			},
+		}, {
 			description: "add unit to existing app",
 			bundleContent: `
                 applications:

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,9 +5,10 @@ github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-0
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
+github.com/juju/naturalsort	git	5b81707e882b8293e6cf77854b4cd49f29776e11	2018-04-23T03:48:42Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
-github.com/juju/testing	git	2fe0e88cf2321d801acedd2b4f0d7f63735fb732	2017-06-08T05:44:51Z
+github.com/juju/testing	git	44801989f0f7f280bd16b58e898ba9337807f147	2018-04-02T13:06:37Z
 github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z

--- a/handlers.go
+++ b/handlers.go
@@ -5,10 +5,10 @@ package bundlechanges
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/naturalsort"
 	"github.com/juju/utils/set"
 	"gopkg.in/juju/charm.v6"
 	"gopkg.in/juju/charmrepo.v2"
@@ -25,7 +25,7 @@ func handleApplications(add func(Change), applications map[string]*charm.Applica
 	for name, _ := range applications {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	naturalsort.Sort(names)
 	var change Change
 	for _, name := range names {
 		application := applications[name]
@@ -165,7 +165,7 @@ func handleMachines(add func(Change), machines map[string]*charm.MachineSpec, de
 	for name, _ := range machines {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	naturalsort.Sort(names)
 	for _, name := range names {
 		machine := machines[name]
 		if machine == nil {
@@ -738,8 +738,8 @@ func fixupConstraintsWithBindings(inputConstraints string, endpointBindings map[
 		outputSpaces = append(outputSpaces, "^"+k)
 	}
 	// To make test tests stable.
-	sort.Strings(outputSpaces)
-	sort.Strings(constraintsKeyList)
+	naturalsort.Sort(outputSpaces)
+	naturalsort.Sort(constraintsKeyList)
 	output := "spaces=" + strings.Join(outputSpaces, ",")
 	for _, constraint := range constraintsKeyList {
 		output += " " + constraint + "=" + constraintsMap[constraint]
@@ -784,7 +784,7 @@ func handleUnits(add func(Change), bundle *charm.BundleData, addedApplications m
 	for name, _ := range bundle.Applications {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	naturalsort.Sort(names)
 
 	processor := &unitProcessor{
 		add:                        add,


### PR DESCRIPTION
Since the machine keys were being sorted alphabetically, the library would try to create machine 10 before machine 2.