### PR TITLE
Detect inconsistent bundle-model machine mappings

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -667,6 +667,20 @@ func (cs *changeset) add(change Change) {
 	cs.changes = append(cs.changes, change)
 }
 
+// dependents returns a map of change-id -> changes that depend on
+// it. We can't calculate this as changes are added because in some
+// cases a change's requirements are updated after it's added to the
+// changeset.
+func (cs *changeset) dependents() map[string][]string {
+	result := make(map[string][]string)
+	for _, change := range cs.changes {
+		for _, dep := range change.Requires() {
+			result[dep] = append(result[dep], change.Id())
+		}
+	}
+	return result
+}
+
 // sorted returns the changes sorted by requirements, required first.
 func (cs *changeset) sorted() []Change {
 	done := set.NewStrings()

--- a/changes_test.go
+++ b/changes_test.go
@@ -1993,10 +1993,10 @@ func (s *changesSuite) assertLocalBundleChanges(c *gc.C, charmDir, bundleContent
 			series,
 			"django",
 			map[string]interface{}{}, // options.
-			"",                  // constraints.
-			map[string]string{}, // storage.
-			map[string]string{}, // endpoint bindings.
-			map[string]int{},    // resources.
+			"",                       // constraints.
+			map[string]string{},      // storage.
+			map[string]string{},      // endpoint bindings.
+			map[string]int{},         // resources.
 		},
 		Requires: []string{"addCharm-0"},
 	}}
@@ -2025,11 +2025,11 @@ func (s *changesSuite) assertLocalBundleChangesWithDevices(c *gc.C, charmDir, bu
 			series,
 			"django",
 			map[string]interface{}{}, // options.
-			"",                  // constraints.
-			map[string]string{}, // storage.
-			map[string]string{}, // devices.
-			map[string]string{}, // endpoint bindings.
-			map[string]int{},    // resources.
+			"",                       // constraints.
+			map[string]string{},      // storage.
+			map[string]string{},      // devices.
+			map[string]string{},      // endpoint bindings.
+			map[string]int{},         // resources.
 		},
 		Requires: []string{"addCharm-0"},
 	}}
@@ -2105,7 +2105,7 @@ func (s *changesSuite) TestCharmInUseByAnotherApplication(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"other-app": &bundlechanges.Application{
+			"other-app": {
 				Charm: "cs:django-4",
 			},
 		},
@@ -2127,7 +2127,7 @@ func (s *changesSuite) TestCharmUpgrade(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Units: []bundlechanges.Unit{
 					{"django/0", "0"},
@@ -2151,7 +2151,7 @@ func (s *changesSuite) TestAppExistsWithLessUnits(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Units: []bundlechanges.Unit{
 					{"django/0", "0"},
@@ -2179,7 +2179,7 @@ func (s *changesSuite) TestNewMachineNumberHigherUnitHigher(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Units: []bundlechanges.Unit{
 					{"django/0", "0"},
@@ -2211,7 +2211,7 @@ func (s *changesSuite) TestAppWithDifferentConstraints(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Units: []bundlechanges.Unit{
 					{"django/0", "0"},
@@ -2242,7 +2242,7 @@ func (s *changesSuite) TestAppExistsWithEnoughUnits(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Units: []bundlechanges.Unit{
 					{"django/0", "0"},
@@ -2271,7 +2271,7 @@ func (s *changesSuite) TestAppExistsWithChangedOptionsAndAnnotations(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Options: map[string]interface{}{
 					"key-1": "value-1",
@@ -2380,7 +2380,7 @@ func (s *changesSuite) TestUnitPlaceNextToOtherNewUnitOnExistingMachine(c *gc.C)
             `
 	existingModel := &bundlechanges.Model{
 		Machines: map[string]*bundlechanges.Machine{
-			"0": &bundlechanges.Machine{ID: "0"},
+			"0": {ID: "0"},
 		},
 		MachineMap: map[string]string{"1": "0"},
 	}
@@ -2436,7 +2436,7 @@ func (s *changesSuite) TestApplicationPlacementSomeExisting(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Units: []bundlechanges.Unit{
 					{"django/0", "0"},
@@ -2478,7 +2478,7 @@ func (s *changesSuite) TestApplicationPlacementSomeColocated(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Units: []bundlechanges.Unit{
 					{"django/0", "0"},
@@ -2486,7 +2486,7 @@ func (s *changesSuite) TestApplicationPlacementSomeColocated(c *gc.C) {
 					{"django/3", "3"},
 				},
 			},
-			"nginx": &bundlechanges.Application{
+			"nginx": {
 				Charm: "cs:nginx",
 				Units: []bundlechanges.Unit{
 					{"nginx/0", "0"},
@@ -2564,7 +2564,7 @@ func (s *changesSuite) TestUnitDeployedDefinedMachine(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"mysql": &bundlechanges.Application{
+			"mysql": {
 				Charm: "cs:mysql",
 				Units: []bundlechanges.Unit{
 					{"mysql/0", "0/lxd/0"},
@@ -2572,8 +2572,8 @@ func (s *changesSuite) TestUnitDeployedDefinedMachine(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0":       &bundlechanges.Machine{ID: "0"},
-			"0/lxd/0": &bundlechanges.Machine{ID: "0/lxd/0"},
+			"0":       {ID: "0"},
+			"0/lxd/0": {ID: "0/lxd/0"},
 		},
 	}
 	expectedChanges := []string{
@@ -2605,7 +2605,7 @@ func (s *changesSuite) TestLXDContainerSequence(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"mysql": &bundlechanges.Application{
+			"mysql": {
 				Charm: "cs:mysql",
 				Units: []bundlechanges.Unit{
 					{"mysql/0", "0/lxd/0"},
@@ -2649,7 +2649,7 @@ func (s *changesSuite) TestMachineMapToExistingMachineSomeDeployed(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"mysql": &bundlechanges.Application{
+			"mysql": {
 				Charm: "cs:mysql",
 				Units: []bundlechanges.Unit{
 					{"mysql/0", "0/lxd/0"},
@@ -2657,10 +2657,10 @@ func (s *changesSuite) TestMachineMapToExistingMachineSomeDeployed(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0":       &bundlechanges.Machine{ID: "0"},
-			"0/lxd/0": &bundlechanges.Machine{ID: "0/lxd/0"},
-			"2":       &bundlechanges.Machine{ID: "2"},
-			"2/lxd/0": &bundlechanges.Machine{ID: "2/lxd/0"},
+			"0":       {ID: "0"},
+			"0/lxd/0": {ID: "0/lxd/0"},
+			"2":       {ID: "2"},
+			"2/lxd/0": {ID: "2/lxd/0"},
 		},
 		MachineMap: map[string]string{
 			"0": "2", // 0 in bundle is machine 2 in existing.
@@ -2702,7 +2702,7 @@ func (s *changesSuite) TestSettingAnnotationsForExistingMachine(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"mysql": &bundlechanges.Application{
+			"mysql": {
 				Charm: "cs:mysql",
 				Units: []bundlechanges.Unit{
 					{"mysql/0", "0/lxd/0"},
@@ -2710,9 +2710,9 @@ func (s *changesSuite) TestSettingAnnotationsForExistingMachine(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0":       &bundlechanges.Machine{ID: "0"},
-			"0/lxd/0": &bundlechanges.Machine{ID: "0/lxd/0"},
-			"2":       &bundlechanges.Machine{ID: "2"},
+			"0":       {ID: "0"},
+			"0/lxd/0": {ID: "0/lxd/0"},
+			"2":       {ID: "2"},
 		},
 		MachineMap: map[string]string{
 			"0": "2", // 0 in bundle is machine 2 in existing.
@@ -2771,7 +2771,7 @@ func (s *changesSuite) TestSiblingContainersSomeDeployed(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"mysql": &bundlechanges.Application{
+			"mysql": {
 				Charm: "cs:mysql",
 				Units: []bundlechanges.Unit{
 					{"mysql/0", "0/lxd/0"},
@@ -2779,7 +2779,7 @@ func (s *changesSuite) TestSiblingContainersSomeDeployed(c *gc.C) {
 					{"mysql/2", "2/lxd/0"},
 				},
 			},
-			"keystone": &bundlechanges.Application{
+			"keystone": {
 				Charm: "cs:keystone",
 				Units: []bundlechanges.Unit{
 					{"keystone/0", "0/lxd/1"},
@@ -2788,14 +2788,14 @@ func (s *changesSuite) TestSiblingContainersSomeDeployed(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0":       &bundlechanges.Machine{ID: "0"},
-			"0/lxd/0": &bundlechanges.Machine{ID: "0/lxd/0"},
-			"0/lxd/1": &bundlechanges.Machine{ID: "0/lxd/1"},
-			"1":       &bundlechanges.Machine{ID: "1"},
-			"1/lxd/0": &bundlechanges.Machine{ID: "1/lxd/0"},
-			"2":       &bundlechanges.Machine{ID: "2"},
-			"2/lxd/0": &bundlechanges.Machine{ID: "2/lxd/0"},
-			"2/lxd/1": &bundlechanges.Machine{ID: "2/lxd/1"},
+			"0":       {ID: "0"},
+			"0/lxd/0": {ID: "0/lxd/0"},
+			"0/lxd/1": {ID: "0/lxd/1"},
+			"1":       {ID: "1"},
+			"1/lxd/0": {ID: "1/lxd/0"},
+			"2":       {ID: "2"},
+			"2/lxd/0": {ID: "2/lxd/0"},
+			"2/lxd/1": {ID: "2/lxd/1"},
 		},
 		Sequence: map[string]int{
 			"machine":              3,
@@ -3062,13 +3062,13 @@ func (s *changesSuite) TestAddUnitToExistingApp(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"mediawiki": &bundlechanges.Application{
+			"mediawiki": {
 				Charm: "cs:precise/mediawiki-10",
 				Units: []bundlechanges.Unit{
 					{"mediawiki/0", "1"},
 				},
 			},
-			"mysql": &bundlechanges.Application{
+			"mysql": {
 				Charm: "cs:precise/mysql-28",
 				Units: []bundlechanges.Unit{
 					{"mysql/0", "0"},
@@ -3076,8 +3076,8 @@ func (s *changesSuite) TestAddUnitToExistingApp(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0": &bundlechanges.Machine{ID: "0"},
-			"1": &bundlechanges.Machine{ID: "1"},
+			"0": {ID: "0"},
+			"1": {ID: "1"},
 		},
 		Relations: []bundlechanges.Relation{
 			{
@@ -3136,7 +3136,7 @@ func (s *changesSuite) TestAddMissingUnitToNotLastPlacement(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"foo": &bundlechanges.Application{
+			"foo": {
 				Charm: "cs:foo",
 				Units: []bundlechanges.Unit{
 					{"foo/1", "1"},
@@ -3145,9 +3145,9 @@ func (s *changesSuite) TestAddMissingUnitToNotLastPlacement(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0": &bundlechanges.Machine{ID: "0"},
-			"1": &bundlechanges.Machine{ID: "1"},
-			"2": &bundlechanges.Machine{ID: "2"},
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+			"2": {ID: "2"},
 		},
 	}
 	expectedChanges := []string{
@@ -3171,7 +3171,7 @@ func (s *changesSuite) TestAddMissingUnitToNotLastPlacementExisting(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"foo": &bundlechanges.Application{
+			"foo": {
 				Charm: "cs:foo",
 				Units: []bundlechanges.Unit{
 					{"foo/1", "1"},
@@ -3180,9 +3180,9 @@ func (s *changesSuite) TestAddMissingUnitToNotLastPlacementExisting(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0": &bundlechanges.Machine{ID: "0"},
-			"1": &bundlechanges.Machine{ID: "1"},
-			"2": &bundlechanges.Machine{ID: "2"},
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+			"2": {ID: "2"},
 		},
 		MachineMap: map[string]string{
 			// map existing machines.
@@ -3222,7 +3222,7 @@ func (s *changesSuite) TestFromJujuMassiveUnitColocation(c *gc.C) {
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
-			"django": &bundlechanges.Application{
+			"django": {
 				Name:  "django",
 				Charm: "cs:xenial/django-42",
 				Units: []bundlechanges.Unit{
@@ -3232,7 +3232,7 @@ func (s *changesSuite) TestFromJujuMassiveUnitColocation(c *gc.C) {
 					{Name: "django/1", Machine: "0/lxd/0"},
 				},
 			},
-			"memcached": &bundlechanges.Application{
+			"memcached": {
 				Name:  "memcached",
 				Charm: "cs:xenial/mem-47",
 				Units: []bundlechanges.Unit{
@@ -3241,7 +3241,7 @@ func (s *changesSuite) TestFromJujuMassiveUnitColocation(c *gc.C) {
 					{Name: "memcached/2", Machine: "2"},
 				},
 			},
-			"ror": &bundlechanges.Application{
+			"ror": {
 				Name:  "ror",
 				Charm: "cs:xenial/rails-0",
 				Units: []bundlechanges.Unit{
@@ -3252,10 +3252,10 @@ func (s *changesSuite) TestFromJujuMassiveUnitColocation(c *gc.C) {
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0": &bundlechanges.Machine{ID: "0"},
-			"1": &bundlechanges.Machine{ID: "1"},
-			"2": &bundlechanges.Machine{ID: "2"},
-			"3": &bundlechanges.Machine{ID: "3"},
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+			"2": {ID: "2"},
+			"3": {ID: "3"},
 		},
 	}
 	expectedChanges := []string{


### PR DESCRIPTION
... and return an error that steers towards the change to fix it.

When a user redeploys a bundle into a model where a previous deploy had some failures which were then corrected manually, and they're using --map-machines=existing, they can get an inconsistency between the bundle and model machines such that bundlechanges creates a new machine but then doesn't host any units on it. This causes a panic in `juju deploy`, as seen in https://pad.lv/1773357.

For example, if you have this bundle:

        applications:
            memcached:
                charm: cs:xenial/memcached-21
                num_units: 2
                to: [0, 1]
        machines:
            0:
            1:

When you deployed it machine 0 failed, so you manually added another unit of memcached (which created machine 2). If you then tried to redeploy the bundle with `--map-machines=existing`, it would see that machine 0 doesn't exist, add a change to create it, see also that there are already two units of memcached, so not create any more - with the end result that there's an empty machine added.

The way to resolve this is to add an explicit mapping that bundle machine 0 corresponds to model machine 2 `--map-machines=existing,0=2`. So now we show an error asking for this mapping - in this case it's pretty obvious, but the situation is likely to be much more complicated (as in the bug above).