### PR TITLE
Add BuildDiff to compare a bundle and model

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -109,9 +109,9 @@ func (d *differ) diffApplication(name string) *ApplicationDiff {
 	result := &ApplicationDiff{
 		Charm:       d.diffStrings(bundle.Charm, model.Charm),
 		Expose:      d.diffBools(bundle.Expose, model.Exposed),
+		Series:      d.diffStrings(bundle.Series, model.Series),
 		Constraints: d.diffStrings(bundle.Constraints, model.Constraints),
 		Options:     d.diffOptions(bundle.Options, model.Options),
-		// TODO(bundlediff): series
 	}
 
 	if d.config.IncludeAnnotations {
@@ -149,13 +149,15 @@ func (d *differ) diffMachines() map[string]*MachineDiff {
 			results[modelName] = &MachineDiff{Missing: ModelSide}
 			continue
 		}
-		// TODO(bundlediff): series
-		diff := &MachineDiff{}
+		diff := &MachineDiff{
+			Series: d.diffStrings(
+				bundleMachine.Series, modelMachine.Series,
+			),
+		}
 
 		if d.config.IncludeAnnotations {
 			diff.Annotations = d.diffAnnotations(
-				bundleMachine.Annotations,
-				modelMachine.Annotations,
+				bundleMachine.Annotations, modelMachine.Annotations,
 			)
 		}
 

--- a/diff.go
+++ b/diff.go
@@ -1,0 +1,99 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package bundlechanges
+
+// DiffSide represents one side of a bundle-model diff.
+type DiffSide string
+
+const (
+	// None represents neither the bundle or model side (used when neither is missing).
+	None DiffSide = ""
+
+	// BundleSide represents the bundle side of a diff.
+	BundleSide DiffSide = "bundle"
+
+	// ModelSide represents the model side of a diff.
+	ModelSide DiffSide = "model"
+)
+
+// NewBundleDiff creates a new empty BundleDiff.
+func NewBundleDiff() *BundleDiff {
+	return &BundleDiff{
+		Applications: make(map[string]*ApplicationDiff),
+		Machines:     make(map[string]*MachineDiff),
+	}
+}
+
+// BundleDiff stores differences between a bundle and a model.
+type BundleDiff struct {
+	Applications map[string]*ApplicationDiff `yaml:"applications,omitempty"`
+	Machines     map[string]*MachineDiff     `yaml:"machines,omitempty"`
+	Series       *StringDiff                 `yaml:"series,omitempty"`
+	Relations    *RelationDiff               `yaml:"relations,omitempty"`
+}
+
+// Empty returns whether the compared bundle and model match (at least
+// in terms of the details we check).
+func (d *BundleDiff) Empty() bool {
+	return len(d.Applications) == 0 &&
+		len(d.Machines) == 0 &&
+		d.Series == nil &&
+		d.Relations == nil
+}
+
+// ApplicationDiff stores differences between an application in a bundle and a model.
+type ApplicationDiff struct {
+	Missing     DiffSide              `yaml:"missing,omitempty"`
+	Charm       *StringDiff           `yaml:"charm,omitempty"`
+	Series      *StringDiff           `yaml:"series,omitempty"`
+	NumUnits    *IntDiff              `yaml:"num_units,omitempty"`
+	Expose      *BoolDiff             `yaml:"expose,omitempty"`
+	Options     map[string]OptionDiff `yaml:"options,omitempty"`
+	Annotations map[string]StringDiff `yaml:"annotations,omitempty"`
+	Constraints *StringDiff           `yaml:"constraints,omitempty"`
+
+	// TODO (bundlediff): resources, storage, devices, endpoint
+	// bindings
+}
+
+// StringDiff stores different bundle and model values for some
+// string.
+type StringDiff struct {
+	Bundle string `yaml:"bundle"`
+	Model  string `yaml:"model"`
+}
+
+// IntDiff stores different bundle and model values for some int.
+type IntDiff struct {
+	Bundle int `yaml:"bundle"`
+	Model  int `yaml:"model"`
+}
+
+// BoolDiff stores different bundle and model values for some bool.
+type BoolDiff struct {
+	Bundle bool `yaml:"bundle"`
+	Model  bool `yaml:"model"`
+}
+
+// OptionDiff stores different bundle and model values for some
+// configuration value.
+type OptionDiff struct {
+	Bundle interface{} `yaml:"bundle"`
+	Model  interface{} `yaml:"model"`
+}
+
+// MachineDiff stores differences between a machine in a bundle and a model.
+type MachineDiff struct {
+	Missing     DiffSide              `yaml:"missing,omitempty"`
+	Constraints *StringDiff           `yaml:"constraints,omitempty"`
+	Annotations map[string]StringDiff `yaml:"annotations,omitempty"`
+	Series      *StringDiff           `yaml:"series,omitempty"`
+}
+
+// RelationDiff stores differences between relations in a bundle and
+// model.
+type RelationDiff struct {
+	BundleExtra [][]string `yaml:"bundle-extra,omitempty"`
+	ModelExtra  [][]string `yaml:"model-extra,omitempty"`
+}

--- a/diff.go
+++ b/diff.go
@@ -70,7 +70,6 @@ func (d *differ) build() (*BundleDiff, error) {
 		Applications: d.diffApplications(),
 		Machines:     d.diffMachines(),
 		Relations:    d.diffRelations(),
-		// TODO(bundlediff): diff series.
 	}, nil
 }
 
@@ -194,33 +193,33 @@ func (d *differ) diffRelations() *RelationsDiff {
 	}
 
 	modelSet := make(map[Relation]bool)
-	var modelExtra []Relation
+	var modelAdditions []Relation
 	for _, original := range d.config.Model.Relations {
 		relation := canonicalRelation(original)
 		modelSet[relation] = true
 		_, found := bundleSet[relation]
 		if !found {
-			modelExtra = append(modelExtra, relation)
+			modelAdditions = append(modelAdditions, relation)
 		}
 	}
 
-	var bundleExtra []Relation
+	var bundleAdditions []Relation
 	for relation := range bundleSet {
 		_, found := modelSet[relation]
 		if !found {
-			bundleExtra = append(bundleExtra, relation)
+			bundleAdditions = append(bundleAdditions, relation)
 		}
 	}
 
-	if len(bundleExtra) == 0 && len(modelExtra) == 0 {
+	if len(bundleAdditions) == 0 && len(modelAdditions) == 0 {
 		return nil
 	}
 
-	sort.Slice(bundleExtra, relationLess(bundleExtra))
-	sort.Slice(modelExtra, relationLess(modelExtra))
+	sort.Slice(bundleAdditions, relationLess(bundleAdditions))
+	sort.Slice(modelAdditions, relationLess(modelAdditions))
 	return &RelationsDiff{
-		BundleExtra: toRelationSlices(bundleExtra),
-		ModelExtra:  toRelationSlices(modelExtra),
+		BundleAdditions: toRelationSlices(bundleAdditions),
+		ModelAdditions:  toRelationSlices(modelAdditions),
 	}
 }
 
@@ -387,8 +386,8 @@ func (d *MachineDiff) Empty() bool {
 // RelationsDiff stores differences between relations in a bundle and
 // model.
 type RelationsDiff struct {
-	BundleExtra [][]string `yaml:"bundle-extra,omitempty"`
-	ModelExtra  [][]string `yaml:"model-extra,omitempty"`
+	BundleAdditions [][]string `yaml:"bundle-additions,omitempty"`
+	ModelAdditions  [][]string `yaml:"model-additions,omitempty"`
 }
 
 // relationFromEndpoints returns a (canonicalised) Relation from a

--- a/diff.go
+++ b/diff.go
@@ -3,6 +3,15 @@
 
 package bundlechanges
 
+import (
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"gopkg.in/juju/charm.v6"
+)
+
 // DiffSide represents one side of a bundle-model diff.
 type DiffSide string
 
@@ -17,12 +26,246 @@ const (
 	ModelSide DiffSide = "model"
 )
 
-// NewBundleDiff creates a new empty BundleDiff.
-func NewBundleDiff() *BundleDiff {
+// DiffConfig provides the values and configuration needed to diff the
+// bundle and model.
+type DiffConfig struct {
+	Bundle *charm.BundleData
+	Model  *Model
+
+	IncludeAnnotations bool
+	Logger             Logger
+}
+
+// BuildDiff returns a BundleDiff with the differences between the
+// passed in bundle and model.
+func BuildDiff(config DiffConfig) (*BundleDiff, error) {
+	differ := &differ{config: config}
+	return differ.build()
+}
+
+type differ struct {
+	config DiffConfig
+}
+
+func (d *differ) build() (*BundleDiff, error) {
 	return &BundleDiff{
-		Applications: make(map[string]*ApplicationDiff),
-		Machines:     make(map[string]*MachineDiff),
+		Applications: d.diffApplications(),
+		Machines:     d.diffMachines(),
+		Relations:    d.diffRelations(),
+		// TODO(bundlediff): diff series.
+	}, nil
+}
+
+func (d *differ) diffApplications() map[string]*ApplicationDiff {
+	// Collect applications from both sides.
+	allApps := set.NewStrings()
+	for app := range d.config.Bundle.Applications {
+		allApps.Add(app)
 	}
+	for app := range d.config.Model.Applications {
+		allApps.Add(app)
+	}
+
+	results := make(map[string]*ApplicationDiff)
+	for _, name := range allApps.SortedValues() {
+		diff := d.diffApplication(name)
+		if diff != nil {
+			results[name] = diff
+		}
+	}
+	if len(results) == 0 {
+		return nil
+	}
+	return results
+}
+
+func (d *differ) diffApplication(name string) *ApplicationDiff {
+	bundle, found := d.config.Bundle.Applications[name]
+	if !found {
+		return &ApplicationDiff{Missing: BundleSide}
+	}
+	model, found := d.config.Model.Applications[name]
+	if !found {
+		return &ApplicationDiff{Missing: ModelSide}
+	}
+	result := &ApplicationDiff{
+		Charm:       d.diffStrings(bundle.Charm, model.Charm),
+		NumUnits:    d.diffInts(bundle.NumUnits, len(model.Units)),
+		Expose:      d.diffBools(bundle.Expose, model.Exposed),
+		Constraints: d.diffStrings(bundle.Constraints, model.Constraints),
+		Options:     d.diffOptions(bundle.Options, model.Options),
+		// TODO(bundlediff): series
+	}
+
+	if d.config.IncludeAnnotations {
+		result.Annotations = d.diffAnnotations(bundle.Annotations, model.Annotations)
+	}
+
+	if result.Empty() {
+		return nil
+	}
+	return result
+}
+
+func (d *differ) diffMachines() map[string]*MachineDiff {
+	// Collect machines from both sides.
+	allNames := set.NewStrings()
+	for name := range d.config.Bundle.Machines {
+		allNames.Add(name)
+	}
+	for name := range d.config.Model.Machines {
+		allNames.Add(name)
+	}
+
+	results := make(map[string]*MachineDiff)
+	for _, name := range allNames.SortedValues() {
+		diff := d.diffMachine(name)
+		if diff != nil {
+			results[name] = diff
+		}
+	}
+	if len(results) == 0 {
+		return nil
+	}
+	return results
+}
+
+func (d *differ) diffMachine(name string) *MachineDiff {
+	bundle, found := d.config.Bundle.Machines[name]
+	if !found {
+		return &MachineDiff{Missing: BundleSide}
+	}
+	if bundle == nil {
+		// This is equivalent to an empty machine spec.
+		bundle = &charm.MachineSpec{}
+	}
+	model, found := d.config.Model.Machines[name]
+	if !found {
+		return &MachineDiff{Missing: ModelSide}
+	}
+	// TODO(bundlediff): series
+	result := &MachineDiff{}
+
+	if d.config.IncludeAnnotations {
+		result.Annotations = d.diffAnnotations(bundle.Annotations, model.Annotations)
+	}
+
+	if result.Empty() {
+		return nil
+	}
+	return result
+}
+
+func (d *differ) diffRelations() *RelationsDiff {
+	bundleSet := make(map[Relation]bool)
+	for _, relation := range d.config.Bundle.Relations {
+		bundleSet[relationFromEndpoints(relation)] = true
+	}
+
+	modelSet := make(map[Relation]bool)
+	var modelExtra []Relation
+	for _, original := range d.config.Model.Relations {
+		relation := canonicalRelation(original)
+		modelSet[relation] = true
+		_, found := bundleSet[relation]
+		if !found {
+			modelExtra = append(modelExtra, relation)
+		}
+	}
+
+	var bundleExtra []Relation
+	for relation := range bundleSet {
+		_, found := modelSet[relation]
+		if !found {
+			bundleExtra = append(bundleExtra, relation)
+		}
+	}
+
+	if len(bundleExtra) == 0 && len(modelExtra) == 0 {
+		return nil
+	}
+
+	sort.Slice(bundleExtra, relationLess(bundleExtra))
+	sort.Slice(modelExtra, relationLess(modelExtra))
+	return &RelationsDiff{
+		BundleExtra: toRelationSlices(bundleExtra),
+		ModelExtra:  toRelationSlices(modelExtra),
+	}
+}
+
+func (d *differ) diffAnnotations(bundle, model map[string]string) map[string]StringDiff {
+	all := set.NewStrings()
+	for name := range bundle {
+		all.Add(name)
+	}
+	for name := range model {
+		all.Add(name)
+	}
+	result := make(map[string]StringDiff)
+	for _, name := range all.Values() {
+		bundleValue := bundle[name]
+		modelValue := model[name]
+		if bundleValue != modelValue {
+			result[name] = StringDiff{
+				Bundle: bundleValue,
+				Model:  modelValue,
+			}
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func (d *differ) diffOptions(bundle, model map[string]interface{}) map[string]OptionDiff {
+	all := set.NewStrings()
+	for name := range bundle {
+		all.Add(name)
+	}
+	for name := range model {
+		all.Add(name)
+	}
+	result := make(map[string]OptionDiff)
+	for _, name := range all.Values() {
+		bundleValue := bundle[name]
+		modelValue := model[name]
+		if !reflect.DeepEqual(bundleValue, modelValue) {
+			result[name] = OptionDiff{
+				Bundle: bundleValue,
+				Model:  modelValue,
+			}
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func (d *differ) diffStrings(bundle, model string) *StringDiff {
+	if bundle == model {
+		return nil
+	}
+	return &StringDiff{Bundle: bundle, Model: model}
+}
+
+func (d *differ) diffInts(bundle, model int) *IntDiff {
+	if bundle == model {
+		return nil
+	}
+	return &IntDiff{Bundle: bundle, Model: model}
+}
+
+func (d *differ) diffBools(bundle, model bool) *BoolDiff {
+	if bundle == model {
+		return nil
+	}
+	return &BoolDiff{Bundle: bundle, Model: model}
+}
+
+func (d *differ) log(message string, args ...interface{}) {
+	d.config.Logger.Tracef(message, args...)
 }
 
 // BundleDiff stores differences between a bundle and a model.
@@ -30,7 +273,7 @@ type BundleDiff struct {
 	Applications map[string]*ApplicationDiff `yaml:"applications,omitempty"`
 	Machines     map[string]*MachineDiff     `yaml:"machines,omitempty"`
 	Series       *StringDiff                 `yaml:"series,omitempty"`
-	Relations    *RelationDiff               `yaml:"relations,omitempty"`
+	Relations    *RelationsDiff              `yaml:"relations,omitempty"`
 }
 
 // Empty returns whether the compared bundle and model match (at least
@@ -55,6 +298,19 @@ type ApplicationDiff struct {
 
 	// TODO (bundlediff): resources, storage, devices, endpoint
 	// bindings
+}
+
+// Empty returns whether the compared bundle and model applications
+// match.
+func (d *ApplicationDiff) Empty() bool {
+	return d.Missing == None &&
+		d.Charm == nil &&
+		d.Series == nil &&
+		d.NumUnits == nil &&
+		d.Expose == nil &&
+		len(d.Options) == 0 &&
+		len(d.Annotations) == 0 &&
+		d.Constraints == nil
 }
 
 // StringDiff stores different bundle and model values for some
@@ -86,14 +342,97 @@ type OptionDiff struct {
 // MachineDiff stores differences between a machine in a bundle and a model.
 type MachineDiff struct {
 	Missing     DiffSide              `yaml:"missing,omitempty"`
-	Constraints *StringDiff           `yaml:"constraints,omitempty"`
 	Annotations map[string]StringDiff `yaml:"annotations,omitempty"`
 	Series      *StringDiff           `yaml:"series,omitempty"`
 }
 
-// RelationDiff stores differences between relations in a bundle and
+// Empty returns whether the compared bundle and model machines match.
+func (d *MachineDiff) Empty() bool {
+	return d.Missing == None &&
+		len(d.Annotations) == 0 &&
+		d.Series == nil
+}
+
+// RelationsDiff stores differences between relations in a bundle and
 // model.
-type RelationDiff struct {
+type RelationsDiff struct {
 	BundleExtra [][]string `yaml:"bundle-extra,omitempty"`
 	ModelExtra  [][]string `yaml:"model-extra,omitempty"`
+}
+
+// relationFromEndpoints returns a (canonicalised) Relation from a
+// [app1:ep1 app2:ep2] bundle relation.
+func relationFromEndpoints(relation []string) Relation {
+	// TODO(bundlediff): verify bundle before we begin so we can rely
+	// on the relations always being 2 app:endpoint strings.
+	relation = relation[:]
+	sort.Strings(relation)
+	parts1 := strings.SplitN(relation[0], ":", 2)
+	parts2 := strings.SplitN(relation[1], ":", 2)
+	return Relation{
+		App1:      parts1[0],
+		Endpoint1: parts1[1],
+		App2:      parts2[0],
+		Endpoint2: parts2[1],
+	}
+}
+
+// canonicalRelation ensures that the endpoints of the relation are in
+// lexicographic order so we can put them into a map and find them
+// even a relation was given to us in the other order.
+func canonicalRelation(relation Relation) Relation {
+	if relation.App1 < relation.App2 {
+		return relation
+	}
+	if relation.App1 == relation.App2 && relation.Endpoint1 <= relation.Endpoint2 {
+		return relation
+	}
+	// The endpoints need to be swapped.
+	return Relation{
+		App1:      relation.App2,
+		Endpoint1: relation.Endpoint2,
+		App2:      relation.App1,
+		Endpoint2: relation.Endpoint1,
+	}
+}
+
+// relationLess returns a func that compares Relations
+// lexicographically.
+func relationLess(relations []Relation) func(i, j int) bool {
+	return func(i, j int) bool {
+		a := relations[i]
+		b := relations[j]
+		if a.App1 < b.App1 {
+			return true
+		}
+		if a.App1 > b.App1 {
+			return false
+		}
+		if a.Endpoint1 < b.Endpoint1 {
+			return true
+		}
+		if a.Endpoint1 > b.Endpoint1 {
+			return false
+		}
+		if a.App2 < b.App2 {
+			return true
+		}
+		if a.App2 > b.App2 {
+			return false
+		}
+		return a.Endpoint2 < b.Endpoint2
+	}
+}
+
+// toRelationSlices converts []Relation to [][]string{{"app:ep",
+// "app:ep"}}.
+func toRelationSlices(relations []Relation) [][]string {
+	result := make([][]string, len(relations))
+	for i, relation := range relations {
+		result[i] = []string{
+			relation.App1 + ":" + relation.Endpoint1,
+			relation.App2 + ":" + relation.Endpoint2,
+		}
+	}
+	return result
 }

--- a/diff.go
+++ b/diff.go
@@ -90,7 +90,6 @@ func (d *differ) diffApplication(name string) *ApplicationDiff {
 	}
 	result := &ApplicationDiff{
 		Charm:       d.diffStrings(bundle.Charm, model.Charm),
-		NumUnits:    d.diffInts(bundle.NumUnits, len(model.Units)),
 		Expose:      d.diffBools(bundle.Expose, model.Exposed),
 		Constraints: d.diffStrings(bundle.Constraints, model.Constraints),
 		Options:     d.diffOptions(bundle.Options, model.Options),
@@ -99,6 +98,10 @@ func (d *differ) diffApplication(name string) *ApplicationDiff {
 
 	if d.config.IncludeAnnotations {
 		result.Annotations = d.diffAnnotations(bundle.Annotations, model.Annotations)
+	}
+	if len(model.SubordinateTo) == 0 {
+		// We don't check num_units for subordinate apps.
+		result.NumUnits = d.diffInts(bundle.NumUnits, len(model.Units))
 	}
 
 	if result.Empty() {

--- a/diff_test.go
+++ b/diff_test.go
@@ -61,7 +61,7 @@ func (s *diffSuite) TestSeriesNotEmpty(c *gc.C) {
 func (s *diffSuite) TestRelationsNotEmpty(c *gc.C) {
 	diff := &bundlechanges.BundleDiff{}
 	diff.Relations = &bundlechanges.RelationsDiff{
-		BundleExtra: [][]string{
+		BundleAdditions: [][]string{
 			{"sinkane:telephone", "bad-sav:hensteeth"},
 		},
 	}
@@ -816,10 +816,10 @@ func (s *diffSuite) TestRelations(c *gc.C) {
 	}
 	expectedDiff := &bundlechanges.BundleDiff{
 		Relations: &bundlechanges.RelationsDiff{
-			BundleExtra: [][]string{
+			BundleAdditions: [][]string{
 				{"memcached:admin", "prometheus:tickling"},
 			},
-			ModelExtra: [][]string{
+			ModelAdditions: [][]string{
 				{"memcached:alligator", "memcached:zebra"},
 				{"memcached:fish", "prometheus:juju-info"},
 			},

--- a/diff_test.go
+++ b/diff_test.go
@@ -4,9 +4,14 @@
 package bundlechanges_test
 
 import (
+	"strings"
+
+	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/bundlechanges"
 )
@@ -17,17 +22,20 @@ type diffSuite struct {
 
 var _ = gc.Suite(&diffSuite{})
 
-func (s *diffSuite) TestDiffing1(c *gc.C) {
-	c.Fatalf("writeme")
+func (s *diffSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	loggo.ConfigureLoggers("diff_test=trace")
 }
 
 func (s *diffSuite) TestNewDiffEmpty(c *gc.C) {
-	diff := bundlechanges.NewBundleDiff()
+	diff := &bundlechanges.BundleDiff{}
 	c.Assert(diff.Empty(), jc.IsTrue)
 }
 
 func (s *diffSuite) TestApplicationsNotEmpty(c *gc.C) {
-	diff := bundlechanges.NewBundleDiff()
+	diff := &bundlechanges.BundleDiff{
+		Applications: make(map[string]*bundlechanges.ApplicationDiff),
+	}
 	diff.Applications["mantell"] = &bundlechanges.ApplicationDiff{
 		Missing: bundlechanges.ModelSide,
 	}
@@ -35,7 +43,9 @@ func (s *diffSuite) TestApplicationsNotEmpty(c *gc.C) {
 }
 
 func (s *diffSuite) TestMachinesNotEmpty(c *gc.C) {
-	diff := bundlechanges.NewBundleDiff()
+	diff := &bundlechanges.BundleDiff{
+		Machines: make(map[string]*bundlechanges.MachineDiff),
+	}
 	diff.Machines["1"] = &bundlechanges.MachineDiff{
 		Missing: bundlechanges.BundleSide,
 	}
@@ -43,17 +53,679 @@ func (s *diffSuite) TestMachinesNotEmpty(c *gc.C) {
 }
 
 func (s *diffSuite) TestSeriesNotEmpty(c *gc.C) {
-	diff := bundlechanges.NewBundleDiff()
+	diff := &bundlechanges.BundleDiff{}
 	diff.Series = &bundlechanges.StringDiff{"xenial", "bionic"}
 	c.Assert(diff.Empty(), jc.IsFalse)
 }
 
 func (s *diffSuite) TestRelationsNotEmpty(c *gc.C) {
-	diff := bundlechanges.NewBundleDiff()
-	diff.Relations = &bundlechanges.RelationDiff{
+	diff := &bundlechanges.BundleDiff{}
+	diff.Relations = &bundlechanges.RelationsDiff{
 		BundleExtra: [][]string{
 			{"sinkane:telephone", "bad-sav:hensteeth"},
 		},
 	}
 	c.Assert(diff.Empty(), jc.IsFalse)
+}
+
+func (s *diffSuite) TestModelMissingApplication(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 2
+                to: [0, 1]
+        machines:
+            0:
+            1:
+            `
+	model := &bundlechanges.Model{
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {Missing: "model"},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestBundleMissingApplication(c *gc.C) {
+	bundleContent := `
+        applications:
+            memcached:
+                charm: cs:xenial/memcached-7
+                num_units: 2
+                to: [0, 1]
+        machines:
+            0:
+            1:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+			"memcached": {
+				Name:  "memcached",
+				Charm: "cs:xenial/memcached-7",
+				Units: []bundlechanges.Unit{
+					{Name: "memcached/0", Machine: "0"},
+					{Name: "memcached/1", Machine: "1"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {Missing: "bundle"},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestMissingApplicationBoth(c *gc.C) {
+	bundleContent := `
+        applications:
+            memcached:
+                charm: cs:xenial/memcached-7
+                num_units: 2
+                to: [0, 1]
+        machines:
+            0:
+            1:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {Missing: "bundle"},
+			"memcached":  {Missing: "model"},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestApplicationCharm(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 2
+                to: [0, 1]
+        machines:
+            0:
+            1:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-8",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+					{Name: "prometheus/1", Machine: "1"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Charm: &bundlechanges.StringDiff{
+					Bundle: "cs:xenial/prometheus-7",
+					Model:  "cs:xenial/prometheus-8",
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+// TODO(bundlediff): model Application.Series isn't there yet.
+// func (s *diffSuite) TestApplicationSeries(c *gc.C) {
+// 	c.Fatalf("writeme")
+// }
+
+// TODO(bundlediff): handle num units for subordinates correctly. If
+// the model says the application is a subordinate we don't compare
+// the number of units.
+func (s *diffSuite) TestApplicationNumUnits(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 2
+                to: [0, 1]
+        machines:
+            0:
+            1:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				NumUnits: &bundlechanges.IntDiff{
+					Bundle: 2,
+					Model:  1,
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestApplicationConstraints(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                constraints: something
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:        "prometheus",
+				Charm:       "cs:xenial/prometheus-7",
+				Constraints: "else",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Constraints: &bundlechanges.StringDiff{
+					Bundle: "something",
+					Model:  "else",
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestApplicationOptions(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                options:
+                    griffin: [shoes, undies]
+                    travis: glasses
+                    clint: hat
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Options: map[string]interface{}{
+					"griffin": []interface{}{"shoes", "undies"},
+					"justin":  "tshirt",
+					"clint":   "scarf",
+				},
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Options: map[string]bundlechanges.OptionDiff{
+					"travis": {"glasses", nil},
+					"justin": {nil, "tshirt"},
+					"clint":  {"hat", "scarf"},
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestApplicationAnnotations(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                annotations:
+                    griffin: shoes
+                    travis: glasses
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Annotations: map[string]string{
+					"griffin": "shorts",
+					"justin":  "tshirt",
+				},
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Annotations: map[string]bundlechanges.StringDiff{
+					"griffin": {"shoes", "shorts"},
+					"travis":  {"glasses", ""},
+					"justin":  {"", "tshirt"},
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestApplicationAnnotationsWithOptionOff(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                annotations:
+                    griffin: shoes
+                    travis: glasses
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Annotations: map[string]string{
+					"griffin": "shorts",
+					"justin":  "tshirt",
+				},
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{}
+	config := bundlechanges.DiffConfig{
+		Bundle:             s.readBundle(c, bundleContent),
+		Model:              model,
+		IncludeAnnotations: false,
+		Logger:             loggo.GetLogger("diff_test"),
+	}
+	s.checkDiffImpl(c, config, expectedDiff, "")
+}
+
+func (s *diffSuite) TestApplicationExpose(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:    "prometheus",
+				Charm:   "cs:xenial/prometheus-7",
+				Exposed: true,
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Expose: &bundlechanges.BoolDiff{
+					Bundle: false,
+					Model:  true,
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestModelMissingMachine(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 2
+                to: [0, 1]
+        machines:
+            0:
+            1:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+					{Name: "prometheus/1", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Machines: map[string]*bundlechanges.MachineDiff{
+			"1": {Missing: "model"},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestBundleMissingMachine(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 2
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+					{Name: "prometheus/1", Machine: "1"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Machines: map[string]*bundlechanges.MachineDiff{
+			"1": {Missing: "bundle"},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestMachineAnnotations(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                to: [0]
+        machines:
+            0:
+                annotations:
+                    scott: pilgrim
+                    dark: knight
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {
+				ID: "0",
+				Annotations: map[string]string{
+					"scott":  "pilgrim",
+					"galaxy": "quest",
+				},
+			},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Machines: map[string]*bundlechanges.MachineDiff{
+			"0": {
+				Annotations: map[string]bundlechanges.StringDiff{
+					"dark":   {"knight", ""},
+					"galaxy": {"", "quest"},
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestMachineAnnotationsWithOptionOff(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                to: [0]
+        machines:
+            0:
+                annotations:
+                    scott: pilgrim
+                    dark: knight
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {
+				ID: "0",
+				Annotations: map[string]string{
+					"scott":  "pilgrim",
+					"galaxy": "quest",
+				},
+			},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{}
+	config := bundlechanges.DiffConfig{
+		Bundle:             s.readBundle(c, bundleContent),
+		Model:              model,
+		IncludeAnnotations: false,
+		Logger:             loggo.GetLogger("diff_test"),
+	}
+	s.checkDiffImpl(c, config, expectedDiff, "")
+}
+
+func (s *diffSuite) TestRelations(c *gc.C) {
+	bundleContent := `
+        applications:
+            memcached:
+                charm: cs:xenial/memcached-7
+                num_units: 1
+                to: [0]
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                to: [1]
+        machines:
+            0:
+            1:
+        relations:
+            - ["memcached:juju-info", "prometheus:target"]
+            - ["memcached:admin", "prometheus:tickling"]
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+			"memcached": {
+				Name:  "memcached",
+				Charm: "cs:xenial/memcached-7",
+				Units: []bundlechanges.Unit{
+					{Name: "memcached/1", Machine: "1"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+		Relations: []bundlechanges.Relation{{
+			App1:      "prometheus",
+			Endpoint1: "target",
+			App2:      "memcached",
+			Endpoint2: "juju-info",
+		}, {
+			App1:      "prometheus",
+			Endpoint1: "juju-info",
+			App2:      "memcached",
+			Endpoint2: "fish",
+		}, {
+			App1:      "memcached",
+			Endpoint1: "zebra",
+			App2:      "memcached",
+			Endpoint2: "alligator",
+		}},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Relations: &bundlechanges.RelationsDiff{
+			BundleExtra: [][]string{
+				{"memcached:admin", "prometheus:tickling"},
+			},
+			ModelExtra: [][]string{
+				{"memcached:alligator", "memcached:zebra"},
+				{"memcached:fish", "prometheus:juju-info"},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) checkDiff(c *gc.C, bundleContent string, model *bundlechanges.Model, expected *bundlechanges.BundleDiff) {
+	config := bundlechanges.DiffConfig{
+		Bundle:             s.readBundle(c, bundleContent),
+		Model:              model,
+		IncludeAnnotations: true,
+		Logger:             loggo.GetLogger("diff_test"),
+	}
+	s.checkDiffImpl(c, config, expected, "")
+}
+
+func (s *diffSuite) checkDiffImpl(c *gc.C, config bundlechanges.DiffConfig, expected *bundlechanges.BundleDiff, errMatch string) {
+
+	diff, err := bundlechanges.BuildDiff(config)
+	if errMatch != "" {
+		c.Assert(err, gc.ErrorMatches, errMatch)
+		c.Assert(diff, gc.IsNil)
+	} else {
+		c.Assert(err, jc.ErrorIsNil)
+		diffOut, err := yaml.Marshal(diff)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Logf("actual: %s", diffOut)
+		expectedOut, err := yaml.Marshal(expected)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Logf("expected: %s", expectedOut)
+		c.Assert(diff, gc.DeepEquals, expected)
+	}
+}
+
+func (s *diffSuite) readBundle(c *gc.C, bundleContent string) *charm.BundleData {
+	data, err := charm.ReadBundleData(strings.NewReader(bundleContent))
+	c.Assert(err, jc.ErrorIsNil)
+	err = data.Verify(nil, nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return data
 }

--- a/diff_test.go
+++ b/diff_test.go
@@ -744,6 +744,60 @@ func (s *diffSuite) TestRelations(c *gc.C) {
 	s.checkDiff(c, bundleContent, model, expectedDiff)
 }
 
+func (s *diffSuite) TestValidationMissingBundle(c *gc.C) {
+	config := bundlechanges.DiffConfig{
+		Bundle: nil,
+		Model:  &bundlechanges.Model{},
+		Logger: loggo.GetLogger("diff_test"),
+	}
+	s.checkDiffImpl(c, config, nil, "nil bundle not valid")
+}
+
+func (s *diffSuite) TestValidationMissingModel(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                to: [0]
+        machines:
+            0:
+            `
+	config := bundlechanges.DiffConfig{
+		Bundle: s.readBundle(c, bundleContent),
+		Model:  nil,
+		Logger: loggo.GetLogger("diff_test"),
+	}
+	s.checkDiffImpl(c, config, nil, "nil model not valid")
+}
+
+func (s *diffSuite) TestValidationMissingLogger(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                to: [0]
+        machines:
+            0:
+            `
+	config := bundlechanges.DiffConfig{
+		Bundle: s.readBundle(c, bundleContent),
+		Model:  &bundlechanges.Model{},
+		Logger: nil,
+	}
+	s.checkDiffImpl(c, config, nil, "nil logger not valid")
+}
+
+func (s *diffSuite) TestValidationInvalidBundle(c *gc.C) {
+	config := bundlechanges.DiffConfig{
+		Bundle: &charm.BundleData{},
+		Model:  &bundlechanges.Model{},
+		Logger: loggo.GetLogger("diff_test"),
+	}
+	s.checkDiffImpl(c, config, nil, "at least one application must be specified")
+}
+
 func (s *diffSuite) checkDiff(c *gc.C, bundleContent string, model *bundlechanges.Model, expected *bundlechanges.BundleDiff) {
 	config := bundlechanges.DiffConfig{
 		Bundle:             s.readBundle(c, bundleContent),

--- a/diff_test.go
+++ b/diff_test.go
@@ -210,10 +210,47 @@ func (s *diffSuite) TestApplicationCharm(c *gc.C) {
 	s.checkDiff(c, bundleContent, model, expectedDiff)
 }
 
-// TODO(bundlediff): model Application.Series isn't there yet.
-// func (s *diffSuite) TestApplicationSeries(c *gc.C) {
-// 	c.Fatalf("writeme")
-// }
+func (s *diffSuite) TestApplicationSeries(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:prometheus-7
+                series: bionic
+                num_units: 2
+                to: [0, 1]
+        machines:
+            0:
+            1:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:   "prometheus",
+				Charm:  "cs:prometheus-7",
+				Series: "xenial",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+					{Name: "prometheus/1", Machine: "1"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {ID: "0"},
+			"1": {ID: "1"},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Series: &bundlechanges.StringDiff{
+					Bundle: "bionic",
+					Model:  "xenial",
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
 
 func (s *diffSuite) TestApplicationNumUnits(c *gc.C) {
 	bundleContent := `
@@ -586,6 +623,47 @@ func (s *diffSuite) TestBundleMissingMachine(c *gc.C) {
 	expectedDiff := &bundlechanges.BundleDiff{
 		Machines: map[string]*bundlechanges.MachineDiff{
 			"0": {Missing: "bundle"},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestMachineSeries(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:xenial/prometheus-7
+                num_units: 1
+                to: [0]
+        machines:
+            0:
+                series: bionic
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:  "prometheus",
+				Charm: "cs:xenial/prometheus-7",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {
+				ID:     "0",
+				Series: "xenial",
+			},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Machines: map[string]*bundlechanges.MachineDiff{
+			"0": {
+				Series: &bundlechanges.StringDiff{
+					Bundle: "bionic",
+					Model:  "xenial",
+				},
+			},
 		},
 	}
 	s.checkDiff(c, bundleContent, model, expectedDiff)

--- a/diff_test.go
+++ b/diff_test.go
@@ -534,13 +534,16 @@ func (s *diffSuite) TestModelMissingMachine(c *gc.C) {
 				Name:  "prometheus",
 				Charm: "cs:xenial/prometheus-7",
 				Units: []bundlechanges.Unit{
-					{Name: "prometheus/0", Machine: "0"},
-					{Name: "prometheus/1", Machine: "0"},
+					{Name: "prometheus/0", Machine: "2"},
+					{Name: "prometheus/1", Machine: "2"},
 				},
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
-			"0": {ID: "0"},
+			"2": {ID: "2"},
+		},
+		MachineMap: map[string]string{
+			"0": "2",
 		},
 	}
 	expectedDiff := &bundlechanges.BundleDiff{
@@ -576,10 +579,13 @@ func (s *diffSuite) TestBundleMissingMachine(c *gc.C) {
 			"0": {ID: "0"},
 			"1": {ID: "1"},
 		},
+		MachineMap: map[string]string{
+			"0": "1",
+		},
 	}
 	expectedDiff := &bundlechanges.BundleDiff{
 		Machines: map[string]*bundlechanges.MachineDiff{
-			"1": {Missing: "bundle"},
+			"0": {Missing: "bundle"},
 		},
 	}
 	s.checkDiff(c, bundleContent, model, expectedDiff)

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,0 +1,59 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package bundlechanges_test
+
+import (
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/bundlechanges"
+)
+
+type diffSuite struct {
+	jujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&diffSuite{})
+
+func (s *diffSuite) TestDiffing1(c *gc.C) {
+	c.Fatalf("writeme")
+}
+
+func (s *diffSuite) TestNewDiffEmpty(c *gc.C) {
+	diff := bundlechanges.NewBundleDiff()
+	c.Assert(diff.Empty(), jc.IsTrue)
+}
+
+func (s *diffSuite) TestApplicationsNotEmpty(c *gc.C) {
+	diff := bundlechanges.NewBundleDiff()
+	diff.Applications["mantell"] = &bundlechanges.ApplicationDiff{
+		Missing: bundlechanges.ModelSide,
+	}
+	c.Assert(diff.Empty(), jc.IsFalse)
+}
+
+func (s *diffSuite) TestMachinesNotEmpty(c *gc.C) {
+	diff := bundlechanges.NewBundleDiff()
+	diff.Machines["1"] = &bundlechanges.MachineDiff{
+		Missing: bundlechanges.BundleSide,
+	}
+	c.Assert(diff.Empty(), jc.IsFalse)
+}
+
+func (s *diffSuite) TestSeriesNotEmpty(c *gc.C) {
+	diff := bundlechanges.NewBundleDiff()
+	diff.Series = &bundlechanges.StringDiff{"xenial", "bionic"}
+	c.Assert(diff.Empty(), jc.IsFalse)
+}
+
+func (s *diffSuite) TestRelationsNotEmpty(c *gc.C) {
+	diff := bundlechanges.NewBundleDiff()
+	diff.Relations = &bundlechanges.RelationDiff{
+		BundleExtra: [][]string{
+			{"sinkane:telephone", "bad-sav:hensteeth"},
+		},
+	}
+	c.Assert(diff.Empty(), jc.IsFalse)
+}

--- a/model.go
+++ b/model.go
@@ -195,6 +195,7 @@ type Application struct {
 	Constraints   string // TODO: not updated yet.
 	Exposed       bool
 	SubordinateTo []string
+	Series        string
 	// TODO: handle changes in:
 	//   endpoint bindings -- possible even?
 	//   storage
@@ -211,6 +212,7 @@ type Unit struct {
 // Machine represents an existing machine in the model.
 type Machine struct {
 	ID          string
+	Series      string
 	Annotations map[string]string
 }
 

--- a/model.go
+++ b/model.go
@@ -82,7 +82,7 @@ func (m *Model) initializeSequence() {
 		}
 	}
 
-	for machineID, _ := range m.Machines {
+	for machineID := range m.Machines {
 		// Continued paranoia.
 		if !names.IsValidMachine(machineID) {
 			continue
@@ -188,12 +188,13 @@ func (m *Model) getUnitMachine(appName string, index int) string {
 
 // Application represents an existing charm deployed in the model.
 type Application struct {
-	Name        string
-	Charm       string // The charm URL.
-	Options     map[string]interface{}
-	Annotations map[string]string
-	Constraints string // TODO: not updated yet.
-	Exposed     bool
+	Name          string
+	Charm         string // The charm URL.
+	Options       map[string]interface{}
+	Annotations   map[string]string
+	Constraints   string // TODO: not updated yet.
+	Exposed       bool
+	SubordinateTo []string
 	// TODO: handle changes in:
 	//   endpoint bindings -- possible even?
 	//   storage


### PR DESCRIPTION
This compares applications, machines and relations and returns a structure of all of the differences between them.

Features still to come include (in priority order):
* Ignoring num_units differences for subordinate applications
* Comparing series on applications, machines and models
* (Down the line further) comparing resources, storage, devices and endpoint bindings.