### PR TITLE
Add support for k8s bundles

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -22,7 +22,7 @@ golang.org/x/net	git	61147c48b25b599e5b561d2e9c4f3e1ef489ca41	2018-04-06T21:48:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/httprequest.v1	git	1a21782420ea13c3c6fb1d03578f446b3248edb1	2018-03-08T16:26:44Z
-gopkg.in/juju/charm.v6	git	5fbb467f7f759a4a2890fc5da0abe4b9b1df20fa	2018-06-29T06:08:46Z
+gopkg.in/juju/charm.v6	git	3469d139dfb3c189a92bebb42f7075fac4bba707	2018-11-07T03:25:05Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z

--- a/diff_test.go
+++ b/diff_test.go
@@ -287,6 +287,39 @@ func (s *diffSuite) TestApplicationNumUnits(c *gc.C) {
 	s.checkDiff(c, bundleContent, model, expectedDiff)
 }
 
+func (s *diffSuite) TestApplicationScale(c *gc.C) {
+	bundleContent := `
+        bundle: kubernetes
+        applications:
+            prometheus:
+                charm: cs:prometheus-7
+                scale: 2
+                placement: foo=bar
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:      "prometheus",
+				Series:    "kubernetes",
+				Charm:     "cs:prometheus-7",
+				Scale:     1,
+				Placement: "foo=bar",
+			},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Scale: &bundlechanges.IntDiff{
+					Bundle: 2,
+					Model:  1,
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
 func (s *diffSuite) TestApplicationSubordinateNumUnits(c *gc.C) {
 	bundleContent := `
         applications:
@@ -545,6 +578,39 @@ func (s *diffSuite) TestApplicationExpose(c *gc.C) {
 				Expose: &bundlechanges.BoolDiff{
 					Bundle: false,
 					Model:  true,
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestApplicationPlacement(c *gc.C) {
+	bundleContent := `
+        bundle: kubernetes
+        applications:
+            prometheus:
+                charm: cs:prometheus-7
+                scale: 2
+                placement: foo=bar
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:      "prometheus",
+				Series:    "kubernetes",
+				Charm:     "cs:prometheus-7",
+				Scale:     2,
+				Placement: "foo=baz",
+			},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Placement: &bundlechanges.StringDiff{
+					Bundle: "foo=bar",
+					Model:  "foo=baz",
 				},
 			},
 		},

--- a/model.go
+++ b/model.go
@@ -14,6 +14,8 @@ import (
 	"gopkg.in/juju/names.v2"
 )
 
+const kubernetes = "kubernetes"
+
 // Model represents the existing deployment if any.
 type Model struct {
 	Applications map[string]*Application
@@ -190,16 +192,17 @@ func (m *Model) getUnitMachine(appName string, index int) string {
 type Application struct {
 	Name          string
 	Charm         string // The charm URL.
+	Scale         int
 	Options       map[string]interface{}
 	Annotations   map[string]string
 	Constraints   string // TODO: not updated yet.
 	Exposed       bool
 	SubordinateTo []string
 	Series        string
+	Placement     string
 	// TODO: handle changes in:
 	//   endpoint bindings -- possible even?
 	//   storage
-	//   series
 
 	Units []Unit
 }


### PR DESCRIPTION
Add support for generating the necessary change events for k8s bundles.
For k8s bundles, unit changes and machine changes are omitted. And applications send the num units with the add event, and there's a new scale application change event.