### PR TITLE
Add create offer change

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -716,6 +716,44 @@ type SetConstraintsParams struct {
 	Constraints string
 }
 
+// CreateOfferChange holds a change for creating a new application endpoint offer.
+type CreateOfferChange struct {
+	changeInfo
+	// Params holds parameters for creating an offer.
+	Params CreateOfferParams
+}
+
+// newCreateOfferChange creates a new change for creating an offer.
+func newCreateOfferChange(params CreateOfferParams, requires ...string) *CreateOfferChange {
+	return &CreateOfferChange{
+		changeInfo: changeInfo{
+			requires: requires,
+			method:   "createOffer",
+		},
+		Params: params,
+	}
+}
+
+// GUIArgs implements Change.GUIArgs.
+func (ch *CreateOfferChange) GUIArgs() []interface{} {
+	return []interface{}{ch.Params.Application, ch.Params.Endpoint, ch.Params.OfferName}
+}
+
+// Description implements Change.
+func (ch *CreateOfferChange) Description() string {
+	return fmt.Sprintf("create an offer with name %q for %s:%s", ch.Params.OfferName, ch.Params.Application, ch.Params.Endpoint)
+}
+
+// CreateOfferParams holds parameters for creating an application offer.
+type CreateOfferParams struct {
+	// Application is the name of the application to create an offer for.
+	Application string
+	// Endpoint is the application endpoint to expose as part of an offer.
+	Endpoint string
+	// OfferName describes the offer name.
+	OfferName string
+}
+
 // changeset holds the list of changes returned by FromData.
 type changeset struct {
 	changes []Change

--- a/changes.go
+++ b/changes.go
@@ -71,6 +71,7 @@ func FromData(config ChangesConfig) ([]Change, error) {
 			return nil, errors.Trace(err)
 		}
 	}
+	resolver.handleOffers(addedApplications)
 	return changes.sorted(), nil
 }
 

--- a/changes_test.go
+++ b/changes_test.go
@@ -198,6 +198,60 @@ func (s *changesSuite) TestMinimalBundleWithDevices(c *gc.C) {
 	s.assertParseDataWithDevices(c, content, expected)
 }
 
+func (s *changesSuite) TestMinimalBundleWithOffer(c *gc.C) {
+	content := `
+applications:
+  apache2:
+    charm: "cs:apache2-26"
+    offers:
+      offer1:
+        endpoint: "apache-website"
+   `
+	expected := []record{
+		{
+			Id:     "addCharm-0",
+			Method: "addCharm",
+			Params: bundlechanges.AddCharmParams{
+				Charm: "cs:apache2-26",
+			},
+			GUIArgs: []interface{}{"cs:apache2-26", ""},
+		},
+		{
+			Id:     "deploy-1",
+			Method: "deploy",
+			Params: bundlechanges.AddApplicationParams{
+				Charm:       "$addCharm-0",
+				Application: "apache2",
+			},
+			GUIArgs: []interface{}{
+				"$addCharm-0",
+				"",
+				"apache2",
+				map[string]interface{}{},
+				"",
+				map[string]string{},
+				map[string]string{},
+				map[string]int{},
+				0,
+			},
+			Requires: []string{"addCharm-0"},
+		},
+		{
+			Id:     "createOffer-2",
+			Method: "createOffer",
+			Params: bundlechanges.CreateOfferParams{
+				Application: "apache2",
+				Endpoint:    "apache-website",
+				OfferName:   "offer1",
+			},
+			GUIArgs:  []interface{}{"apache2", "apache-website", "offer1"},
+			Requires: []string{"deploy-1"},
+		},
+	}
+
+	s.assertParseData(c, content, expected)
+}
+
 func (s *changesSuite) TestSimpleBundle(c *gc.C) {
 	content := `
         applications:

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,3 +1,4 @@
+github.com/gobwas/glob	git	e7a84e9525fe90abcda167b604e483cc959ad4aa	2018-10-02T19:08:08Z
 github.com/juju/collections	git	520e0549d51ae2b50f44f4df2b145a780a5bc6e0	2018-05-15T20:37:31Z
 github.com/juju/errors	git	1b5e39b83d1835fa480e0c2ddefb040ee82d58b3	2015-09-16T12:56:42Z
 github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-02-04T19:46:29Z
@@ -7,6 +8,7 @@ github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
 github.com/juju/naturalsort	git	5b81707e882b8293e6cf77854b4cd49f29776e11	2018-04-23T03:48:42Z
+github.com/juju/os	git	0ffd1641ec10b98d99eabb23729a2156244da119	2018-11-02T05:00:08Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
 github.com/juju/testing	git	44801989f0f7f280bd16b58e898ba9337807f147	2018-04-02T13:06:37Z
@@ -19,10 +21,12 @@ github.com/kr/text	git	7cafcd837844e784b526369c9bce262804aebc60	2016-05-04T23:40
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 golang.org/x/crypto	git	650f4a345ab4e5b245a3034b110ebc7299e68186	2018-02-14T00:00:28Z
 golang.org/x/net	git	61147c48b25b599e5b561d2e9c4f3e1ef489ca41	2018-04-06T21:48:16Z
+golang.org/x/sys	git	afcc84fd7533758f95a6e93ae710aa945a0b7e73	2019-02-01T15:26:29Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
+gopkg.in/gobwas/glob.v0	git	5ccd90ef52e1e632236f7326478d4faa74f99438	2018-02-08T21:06:56Z
 gopkg.in/httprequest.v1	git	1a21782420ea13c3c6fb1d03578f446b3248edb1	2018-03-08T16:26:44Z
-gopkg.in/juju/charm.v6	git	3469d139dfb3c189a92bebb42f7075fac4bba707	2018-11-07T03:25:05Z
+gopkg.in/juju/charm.v6	git	a3c5f8f514faf216cc54061a47e86bae1fef79af	2019-06-14T11:28:48Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z

--- a/handlers.go
+++ b/handlers.go
@@ -309,6 +309,19 @@ func (r *resolver) handleRelations(addedApplications map[string]string) {
 	}
 }
 
+// handleOffers populates the change set with "CreateOffer" records.
+func (r *resolver) handleOffers(addedApplications map[string]string) {
+	for appName, appSpec := range r.bundle.Applications {
+		for offerName, offerSpec := range appSpec.Offers {
+			r.changes.add(newCreateOfferChange(CreateOfferParams{
+				Application: appName,
+				Endpoint:    offerSpec.Endpoint,
+				OfferName:   offerName,
+			}, addedApplications[appName]))
+		}
+	}
+}
+
 type unitProcessor struct {
 	add           func(Change)
 	existing      *Model


### PR DESCRIPTION
This PR introduces a new Change type called `CreateOfferChange`. This new change type will be used for re-creating application offers if defined within the bundle (see https://github.com/juju/charm/pull/277).