### PR TITLE
Support multiple endpoints for create offer changes

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -737,20 +737,20 @@ func newCreateOfferChange(params CreateOfferParams, requires ...string) *CreateO
 
 // GUIArgs implements Change.GUIArgs.
 func (ch *CreateOfferChange) GUIArgs() []interface{} {
-	return []interface{}{ch.Params.Application, ch.Params.Endpoint, ch.Params.OfferName}
+	return []interface{}{ch.Params.Application, ch.Params.Endpoints, ch.Params.OfferName}
 }
 
 // Description implements Change.
 func (ch *CreateOfferChange) Description() string {
-	return fmt.Sprintf("create an offer with name %q for %s:%s", ch.Params.OfferName, ch.Params.Application, ch.Params.Endpoint)
+	return fmt.Sprintf("create an offer with name %q for %s:%v", ch.Params.OfferName, ch.Params.Application, ch.Params.Endpoints)
 }
 
 // CreateOfferParams holds parameters for creating an application offer.
 type CreateOfferParams struct {
 	// Application is the name of the application to create an offer for.
 	Application string
-	// Endpoint is the application endpoint to expose as part of an offer.
-	Endpoint string
+	// Endpoint is a list of application endpoint to expose as part of an offer.
+	Endpoints []string
 	// OfferName describes the offer name.
 	OfferName string
 }

--- a/changes_test.go
+++ b/changes_test.go
@@ -205,7 +205,9 @@ applications:
     charm: "cs:apache2-26"
     offers:
       offer1:
-        endpoint: "apache-website"
+        endpoints:
+          - "apache-website"
+          - "apache-proxy"
    `
 	expected := []record{
 		{
@@ -241,10 +243,13 @@ applications:
 			Method: "createOffer",
 			Params: bundlechanges.CreateOfferParams{
 				Application: "apache2",
-				Endpoint:    "apache-website",
-				OfferName:   "offer1",
+				Endpoints: []string{
+					"apache-website",
+					"apache-proxy",
+				},
+				OfferName: "offer1",
 			},
-			GUIArgs:  []interface{}{"apache2", "apache-website", "offer1"},
+			GUIArgs:  []interface{}{"apache2", []string{"apache-website", "apache-proxy"}, "offer1"},
 			Requires: []string{"deploy-1"},
 		},
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -26,7 +26,7 @@ gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/gobwas/glob.v0	git	5ccd90ef52e1e632236f7326478d4faa74f99438	2018-02-08T21:06:56Z
 gopkg.in/httprequest.v1	git	1a21782420ea13c3c6fb1d03578f446b3248edb1	2018-03-08T16:26:44Z
-gopkg.in/juju/charm.v6	git	a3c5f8f514faf216cc54061a47e86bae1fef79af	2019-06-14T11:28:48Z
+gopkg.in/juju/charm.v6	git	b0b4c5138c321b98c1497ddf436f1e49b8b35ae2	2019-06-18T12:53:29Z
 gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z

--- a/handlers.go
+++ b/handlers.go
@@ -315,7 +315,7 @@ func (r *resolver) handleOffers(addedApplications map[string]string) {
 		for offerName, offerSpec := range appSpec.Offers {
 			r.changes.add(newCreateOfferChange(CreateOfferParams{
 				Application: appName,
-				Endpoint:    offerSpec.Endpoint,
+				Endpoints:   offerSpec.Endpoints,
 				OfferName:   offerName,
 			}, addedApplications[appName]))
 		}


### PR DESCRIPTION
This PR ensures that the `CreateOfferChange` supports multiple endpoints for application offers.