### PR TITLE
Update AddCharm change type to include the channel

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -148,16 +148,20 @@ type AddCharmChange struct {
 
 // GUIArgs implements Change.GUIArgs.
 func (ch *AddCharmChange) GUIArgs() []interface{} {
-	return []interface{}{ch.Params.Charm, ch.Params.Series}
+	return []interface{}{ch.Params.Charm, ch.Params.Series, ch.Params.Channel}
 }
 
 // Description implements Change.
 func (ch *AddCharmChange) Description() string {
-	series := ""
+	var series, channel string
 	if ch.Params.Series != "" {
 		series = " for series " + ch.Params.Series
 	}
-	return fmt.Sprintf("upload charm %s%s", ch.Params.Charm, series)
+	if ch.Params.Channel != "" {
+		channel = " from channel " + ch.Params.Channel
+	}
+
+	return fmt.Sprintf("upload charm %s%s%s", ch.Params.Charm, series, channel)
 }
 
 // AddCharmParams holds parameters for adding a charm to the environment.
@@ -167,6 +171,8 @@ type AddCharmParams struct {
 	// Series holds the series of the charm to be added
 	// if the charm default is not sufficient.
 	Series string
+	// Channel holds the preferred channel for obtaining the charm.
+	Channel string
 }
 
 // newUpgradeCharm upgrades an existing charm to a new version.

--- a/changes_test.go
+++ b/changes_test.go
@@ -58,7 +58,7 @@ func (s *changesSuite) TestMinimalBundle(c *gc.C) {
 		Params: bundlechanges.AddCharmParams{
 			Charm: "django",
 		},
-		GUIArgs: []interface{}{"django", ""},
+		GUIArgs: []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -83,6 +83,44 @@ func (s *changesSuite) TestMinimalBundle(c *gc.C) {
 	s.assertParseData(c, content, expected)
 }
 
+func (s *changesSuite) TestMinimalBundleWithChannels(c *gc.C) {
+	content := `
+        applications:
+            django:
+                charm: django
+                channel: edge
+   `
+	expected := []record{{
+		Id:     "addCharm-0",
+		Method: "addCharm",
+		Params: bundlechanges.AddCharmParams{
+			Charm:   "django",
+			Channel: "edge",
+		},
+		GUIArgs: []interface{}{"django", "", "edge"},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Params: bundlechanges.AddApplicationParams{
+			Charm:       "$addCharm-0",
+			Application: "django",
+		},
+		GUIArgs: []interface{}{
+			"$addCharm-0",
+			"",
+			"django",
+			map[string]interface{}{},
+			"",
+			map[string]string{},
+			map[string]string{},
+			map[string]int{},
+			0,
+		},
+		Requires: []string{"addCharm-0"},
+	}}
+
+	s.assertParseData(c, content, expected)
+}
 func (s *changesSuite) TestBundleURLAnnotationSet(c *gc.C) {
 	content := `
         services:
@@ -95,7 +133,7 @@ func (s *changesSuite) TestBundleURLAnnotationSet(c *gc.C) {
 		Params: bundlechanges.AddCharmParams{
 			Charm: "django",
 		},
-		GUIArgs: []interface{}{"django", ""},
+		GUIArgs: []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -172,7 +210,7 @@ func (s *changesSuite) TestMinimalBundleWithDevices(c *gc.C) {
 		Params: bundlechanges.AddCharmParams{
 			Charm: "django",
 		},
-		GUIArgs: []interface{}{"django", ""},
+		GUIArgs: []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -219,7 +257,7 @@ applications:
 			Params: bundlechanges.AddCharmParams{
 				Charm: "cs:apache2-26",
 			},
-			GUIArgs: []interface{}{"cs:apache2-26", ""},
+			GUIArgs: []interface{}{"cs:apache2-26", "", ""},
 		},
 		{
 			Id:     "deploy-1",
@@ -290,7 +328,7 @@ applications:
 			Params: bundlechanges.AddCharmParams{
 				Charm: "cs:apache2-26",
 			},
-			GUIArgs: []interface{}{"cs:apache2-26", ""},
+			GUIArgs: []interface{}{"cs:apache2-26", "", ""},
 		},
 		{
 			Id:     "deploy-1",
@@ -361,7 +399,7 @@ relations:
 			Params: bundlechanges.AddCharmParams{
 				Charm: "cs:apache2-26",
 			},
-			GUIArgs: []interface{}{"cs:apache2-26", ""},
+			GUIArgs: []interface{}{"cs:apache2-26", "", ""},
 		},
 		{
 			Id:     "deploy-1",
@@ -439,7 +477,7 @@ func (s *changesSuite) TestSimpleBundle(c *gc.C) {
 			Charm:  "cs:precise/mediawiki-10",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"cs:precise/mediawiki-10", "precise"},
+		GUIArgs: []interface{}{"cs:precise/mediawiki-10", "precise", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -491,7 +529,7 @@ func (s *changesSuite) TestSimpleBundle(c *gc.C) {
 			Charm:  "cs:precise/mysql-28",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"cs:precise/mysql-28", "precise"},
+		GUIArgs: []interface{}{"cs:precise/mysql-28", "precise", ""},
 	}, {
 		Id:     "deploy-5",
 		Method: "deploy",
@@ -574,7 +612,7 @@ func (s *changesSuite) TestSimpleBundleWithDevices(c *gc.C) {
 			Charm:  "cs:precise/mediawiki-10",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"cs:precise/mediawiki-10", "precise"},
+		GUIArgs: []interface{}{"cs:precise/mediawiki-10", "precise", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -627,7 +665,7 @@ func (s *changesSuite) TestSimpleBundleWithDevices(c *gc.C) {
 			Charm:  "cs:precise/mysql-28",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"cs:precise/mysql-28", "precise"},
+		GUIArgs: []interface{}{"cs:precise/mysql-28", "precise", ""},
 	}, {
 		Id:     "deploy-5",
 		Method: "deploy",
@@ -711,7 +749,7 @@ func (s *changesSuite) TestKubernetesBundle(c *gc.C) {
 			Charm:  "cs:mediawiki-k8s-10",
 			Series: "kubernetes",
 		},
-		GUIArgs: []interface{}{"cs:mediawiki-k8s-10", "kubernetes"},
+		GUIArgs: []interface{}{"cs:mediawiki-k8s-10", "kubernetes", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -765,7 +803,7 @@ func (s *changesSuite) TestKubernetesBundle(c *gc.C) {
 			Charm:  "cs:mysql-k8s-28",
 			Series: "kubernetes",
 		},
-		GUIArgs: []interface{}{"cs:mysql-k8s-28", "kubernetes"},
+		GUIArgs: []interface{}{"cs:mysql-k8s-28", "kubernetes", ""},
 	}, {
 		Id:     "deploy-5",
 		Method: "deploy",
@@ -819,7 +857,7 @@ func (s *changesSuite) TestSameCharmReused(c *gc.C) {
 			Charm:  "precise/mediawiki-10",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"precise/mediawiki-10", "precise"},
+		GUIArgs: []interface{}{"precise/mediawiki-10", "precise", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -908,7 +946,7 @@ func (s *changesSuite) TestMachinesAndUnitsPlacementWithBindings(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -938,7 +976,7 @@ func (s *changesSuite) TestMachinesAndUnitsPlacementWithBindings(c *gc.C) {
 			Charm:  "cs:trusty/haproxy-47",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/haproxy-47", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/haproxy-47", "trusty", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -1092,7 +1130,7 @@ func (s *changesSuite) TestMachinesWithConstraintsAndAnnotations(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -1191,7 +1229,7 @@ func (s *changesSuite) TestEndpointWithoutRelationName(c *gc.C) {
 			Charm:  "cs:precise/mediawiki-10",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"cs:precise/mediawiki-10", "precise"},
+		GUIArgs: []interface{}{"cs:precise/mediawiki-10", "precise", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -1219,7 +1257,7 @@ func (s *changesSuite) TestEndpointWithoutRelationName(c *gc.C) {
 			Charm:  "cs:precise/mysql-28",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"cs:precise/mysql-28", "precise"},
+		GUIArgs: []interface{}{"cs:precise/mysql-28", "precise", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -1273,7 +1311,7 @@ func (s *changesSuite) TestUnitPlacedInApplication(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -1300,7 +1338,7 @@ func (s *changesSuite) TestUnitPlacedInApplication(c *gc.C) {
 		Params: bundlechanges.AddCharmParams{
 			Charm: "wordpress",
 		},
-		GUIArgs: []interface{}{"wordpress", ""},
+		GUIArgs: []interface{}{"wordpress", "", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -1385,7 +1423,7 @@ func (s *changesSuite) TestUnitPlacedInApplicationWithDevices(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -1413,7 +1451,7 @@ func (s *changesSuite) TestUnitPlacedInApplicationWithDevices(c *gc.C) {
 		Params: bundlechanges.AddCharmParams{
 			Charm: "wordpress",
 		},
-		GUIArgs: []interface{}{"wordpress", ""},
+		GUIArgs: []interface{}{"wordpress", "", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -1513,7 +1551,7 @@ func (s *changesSuite) TestUnitColocationWithOtherUnits(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -1541,7 +1579,7 @@ func (s *changesSuite) TestUnitColocationWithOtherUnits(c *gc.C) {
 			Charm:  "cs:trusty/mem-47",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/mem-47", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/mem-47", "trusty", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -1569,7 +1607,7 @@ func (s *changesSuite) TestUnitColocationWithOtherUnits(c *gc.C) {
 			Charm:  "vivid/rails",
 			Series: "vivid",
 		},
-		GUIArgs: []interface{}{"vivid/rails", "vivid"},
+		GUIArgs: []interface{}{"vivid/rails", "vivid", ""},
 	}, {
 		Id:     "deploy-5",
 		Method: "deploy",
@@ -1818,7 +1856,7 @@ func (s *changesSuite) TestUnitPlacedToMachines(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -1981,7 +2019,7 @@ func (s *changesSuite) TestUnitPlacedToNewMachineWithConstraints(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -2047,7 +2085,7 @@ func (s *changesSuite) TestApplicationWithStorage(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -2115,7 +2153,7 @@ func (s *changesSuite) TestApplicationWithDevices(c *gc.C) {
 			Charm:  "cs:trusty/django-42",
 			Series: "trusty",
 		},
-		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty"},
+		GUIArgs: []interface{}{"cs:trusty/django-42", "trusty", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -2183,7 +2221,7 @@ func (s *changesSuite) TestApplicationWithEndpointBindings(c *gc.C) {
 		Params: bundlechanges.AddCharmParams{
 			Charm: "django",
 		},
-		GUIArgs: []interface{}{"django", ""},
+		GUIArgs: []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -2229,7 +2267,7 @@ machines:
 			Charm:  "cs:precise/juju-gui",
 			Series: "precise",
 		},
-		GUIArgs: []interface{}{"cs:precise/juju-gui", "precise"},
+		GUIArgs: []interface{}{"cs:precise/juju-gui", "precise", ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -2416,7 +2454,7 @@ func (s *changesSuite) assertLocalBundleChanges(c *gc.C, charmDir, bundleContent
 			Charm:  charmDir,
 			Series: series,
 		},
-		GUIArgs: []interface{}{charmDir, series},
+		GUIArgs: []interface{}{charmDir, series, ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -2449,7 +2487,7 @@ func (s *changesSuite) assertLocalBundleChangesWithDevices(c *gc.C, charmDir, bu
 			Charm:  charmDir,
 			Series: series,
 		},
-		GUIArgs: []interface{}{charmDir, series},
+		GUIArgs: []interface{}{charmDir, series, ""},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -18,6 +18,7 @@ github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
 github.com/kr/pretty	git	cfb55aafdaf3ec08f0db22699ab822c50091b1c4	2016-08-23T17:07:15Z
 github.com/kr/text	git	7cafcd837844e784b526369c9bce262804aebc60	2016-05-04T23:40:17Z
+github.com/mohae/deepcopy	git	c48cc78d482608239f6c4c92a4abd87eb8761c90	2017-09-29T03:49:55Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 golang.org/x/crypto	git	650f4a345ab4e5b245a3034b110ebc7299e68186	2018-02-14T00:00:28Z
 golang.org/x/net	git	61147c48b25b599e5b561d2e9c4f3e1ef489ca41	2018-04-06T21:48:16Z
@@ -26,10 +27,10 @@ gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/gobwas/glob.v0	git	5ccd90ef52e1e632236f7326478d4faa74f99438	2018-02-08T21:06:56Z
 gopkg.in/httprequest.v1	git	1a21782420ea13c3c6fb1d03578f446b3248edb1	2018-03-08T16:26:44Z
-gopkg.in/juju/charm.v6	git	52b617a34c5a360391bb84d0e7fe40912141ff17	2019-06-27T11:32:48Z
-gopkg.in/juju/charmrepo.v2	git	653bbd81990d2d7d48e0fb931a3b0f52c694572f	2017-11-14T18:40:45Z
+gopkg.in/juju/charm.v6	git	40ffcf7d10e526b8cc5c02dba9758a6c73544d4c	2019-07-29T11:31:11Z
+gopkg.in/juju/charmrepo.v3	git	5d556784448743d47989aaf473d3ef2382e254b1	2018-10-19T14:38:50Z
 gopkg.in/juju/names.v2	git	c43e8bdf2f4915a7019a2f8ad561af1498731a21	2018-05-16T01:04:14Z
-gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
-gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
+gopkg.in/macaroon-bakery.v2-unstable	git	5a131df02b2333d5d75c501743cbc2948ee9bbf0	2016-06-23T14:27:47Z
+gopkg.in/macaroon.v2-unstable	git	7d806ab8652997999d67d41b894beb0ffd549793	2016-06-14T11:13:15Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z
-gopkg.in/yaml.v2	git	1be3d31502d6eabc0dd7ce5b0daab022e14a5538	2017-07-12T05:45:46Z
+gopkg.in/yaml.v2	git	51d6538a90f86fe93ac480b35f37b2be17fef232	2018-11-15T11:05:04Z

--- a/handlers.go
+++ b/handlers.go
@@ -50,8 +50,9 @@ func (r *resolver) handleApplications() map[string]string {
 		// Add the addCharm record if one hasn't been added yet.
 		if charms[application.Charm] == "" && !existing.hasCharm(application.Charm) {
 			change = newAddCharmChange(AddCharmParams{
-				Charm:  application.Charm,
-				Series: series,
+				Charm:   application.Charm,
+				Series:  series,
+				Channel: application.Channel,
 			})
 			add(change)
 			charms[application.Charm] = change.Id()

--- a/handlers.go
+++ b/handlers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
 	"gopkg.in/juju/charm.v6"
-	"gopkg.in/juju/charmrepo.v2"
+	"gopkg.in/juju/charmrepo.v3"
 )
 
 type resolver struct {


### PR DESCRIPTION
This PR is part of the work required to support bundles that can specify a per-charm channel preference.

The PR also includes a small drive-by fix to remove an old dependency to charmrepo.v2 which ends up in juju's transient dependency list.