### PR TITLE
Fix local relative charm and invalid URL panic

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -60,7 +60,10 @@ func FromData(config ChangesConfig) ([]Change, error) {
 		logger:    config.Logger,
 		changes:   changes,
 	}
-	addedApplications := resolver.handleApplications()
+	addedApplications, err := resolver.handleApplications()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	var addedMachines map[string]*AddMachineChange
 	if resolver.bundle.Type != kubernetes {


### PR DESCRIPTION
# Fix local relative charm and invalid URL panic
- Local relative paths no longer get parsed by ParseURL. Default to the defaultSeries.
- Handle errors returned by ParseURL to fix panics.