### PR TITLE
Substitute empty string for missing relation endpoints when diffing

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -400,6 +400,17 @@ func relationFromEndpoints(relation []string) Relation {
 	sort.Strings(relation)
 	parts1 := strings.SplitN(relation[0], ":", 2)
 	parts2 := strings.SplitN(relation[1], ":", 2)
+
+	// According to our docs, bundles may optionally omit the endpoint from
+	// relations which will cause an index out of bounds panic when trying
+	// to construct the Relation instance below.
+	if len(parts1) == 1 {
+		parts1 = append(parts1, "")
+	}
+	if len(parts2) == 1 {
+		parts2 = append(parts2, "")
+	}
+
 	return Relation{
 		App1:      parts1[0],
 		Endpoint1: parts1[1],


### PR DESCRIPTION
According to the bundle schema [docs](https://juju.is/docs/bundle-reference), a bundle may omit the endpoint from the relation list. As a result, when diffing against such a bundle, an index out of bounds panic would be generated.

This PR avoids the panic by substituting an empty endpoint. Note that this patch will generate spurious diff entries (see test in https://github.com/juju/bundlechanges/commit/41b62b9db3b1f0b8ac37807b8e2a64d27ab63d6c). The plan is to have juju emit a warning for the missing endpoints and advise the operator to update their local bundle.

Related bug: https://bugs.launchpad.net/juju/+bug/1882573