### PR TITLE
Adding deterministic processing of bundle machines

### DIFF
--- a/model.go
+++ b/model.go
@@ -5,6 +5,7 @@ package bundlechanges
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/juju/charm/v7"
@@ -465,6 +466,7 @@ func (e *inferenceEngine) processInitialPlacements() {
 				unused = unused[:len(unused)-1]
 			}
 		}
+		sort.Strings(unused)
 		e.appPlacements[appName] = unused
 		e.logger.Tracef("unused placements: %#v", unused)
 	}
@@ -490,6 +492,12 @@ func (e *inferenceEngine) processBundleMachines() {
 	}
 	naturalsort.Sort(ids)
 
+	applications := make([]string, 0, len(e.bundle.Applications))
+	for appName := range e.bundle.Applications {
+		applications = append(applications, appName)
+	}
+	sort.Strings(applications)
+
 mainloop:
 	for _, id := range ids {
 		// The simplest case is where the user has specified a mapping
@@ -499,7 +507,7 @@ mainloop:
 		}
 		e.logger.Tracef("machine: %s", id)
 		// Look for a unit placement directive that specifies the machine.
-		for appName := range e.bundle.Applications {
+		for _, appName := range applications {
 			e.logger.Tracef("app: %s", appName)
 			for _, to := range e.appPlacements[appName] {
 				// Here we explicitly ignore the error return of the parse placement

--- a/model_test.go
+++ b/model_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/charm/v7"
 	"github.com/juju/loggo"
+	"github.com/juju/naturalsort"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -417,6 +418,110 @@ func (s *inferMachineMapSuite) TestOffest(c *gc.C) {
 	c.Assert(model.MachineMap, jc.DeepEquals, map[string]string{
 		"1": "1", "2": "2", "3": "0",
 	})
+}
+
+// Fixing LP #1883645
+func (s *inferMachineMapSuite) TestBundleMachinesDeterminism(c *gc.C) {
+	data := s.parseBundle(c, `
+        series: bionic
+        machines:
+            "0":
+                series: bionic
+            "1":
+                series: bionic
+            "2":
+                series: bionic
+            "10":
+                series: bionic
+            "11":
+                series: bionic
+            "12":
+                series: bionic
+            "20":
+                series: bionic
+            "21":
+                series: bionic
+            "22":
+                series: bionic
+        applications:
+            ubuntu:
+                num_units: 6
+                charm: ubuntu
+                to:
+                - 0
+                - 1
+                - 2
+                - 10
+                - 11
+                - 12
+            memcached:
+                num_units: 6
+                charm: cs:memcached
+                to:
+                - 10
+                - 12
+                - 13
+                - 20
+                - 21
+                - 22
+`)
+	model := &Model{
+		Applications: map[string]*Application{
+			"ubuntu": &Application{
+				Units: []Unit{
+					{"ubuntu/0", "0"},
+					{"ubuntu/1", "1"},
+					{"ubuntu/2", "2"},
+					{"ubuntu/3", "10"},
+					{"ubuntu/4", "11"},
+					{"ubuntu/5", "12"},
+				},
+			},
+			"memcached": &Application{
+				Units: []Unit{
+					{"memcached/0", "10"},
+					{"memcached/1", "11"},
+					{"memcached/2", "12"},
+				},
+			},
+		},
+		Machines: map[string]*Machine{
+			"0":  &Machine{ID: "0"},
+			"1":  &Machine{ID: "1"},
+			"2":  &Machine{ID: "2"},
+			"10": &Machine{ID: "10"},
+			"11": &Machine{ID: "11"},
+			"12": &Machine{ID: "12"},
+		},
+		logger: loggo.GetLogger("bundlechanges"),
+	}
+
+	// Loop through enough times to trigger a potential map ordering bug.
+	for i := 0; i < 10; i++ {
+		model.initializeSequence()
+		model.InferMachineMap(data)
+		c.Assert(model.MachineMap, jc.DeepEquals, map[string]string{
+			"0": "0", "1": "1", "2": "2", "10": "10", "11": "11", "12": "12",
+		})
+
+		names := make([]string, 0, len(data.Machines))
+		for name := range data.Machines {
+			names = append(names, name)
+		}
+		naturalsort.Sort(names)
+
+		var got [][]string
+		for _, machine := range names {
+			if model.BundleMachine(machine) == nil {
+				got = append(got, []string{machine, model.nextMachine()})
+			}
+		}
+		c.Assert(got, jc.DeepEquals, [][]string{
+			{"20", "13"},
+			{"21", "14"},
+			{"22", "15"},
+		})
+	}
 }
 
 type applicationSuite struct{}


### PR DESCRIPTION
The following ensure that the applications that we loop through are
deterministic, so that when adding application units we skip correctly
with in the loop.

This is fixing LP #1883645