### PR TITLE
Include expose params in expose application change

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/juju/charm/v8"
@@ -624,6 +625,7 @@ func (ch *ExposeChange) Description() string {
 	fmt.Fprint(&descr, "expose ")
 
 	if len(ch.Params.ExposedEndpoints) != 0 {
+		sort.Strings(ch.Params.ExposedEndpoints)
 		fmt.Fprintf(&descr, "endpoint(s) %s of ", strings.Join(ch.Params.ExposedEndpoints, ","))
 	}
 
@@ -632,6 +634,7 @@ func (ch *ExposeChange) Description() string {
 	if spaceCount, cidrCount := len(ch.Params.ExposeToSpaces), len(ch.Params.ExposeToCIDRs); spaceCount+cidrCount != 0 {
 		fmt.Fprintf(&descr, " to ")
 		if spaceCount != 0 {
+			sort.Strings(ch.Params.ExposeToSpaces)
 			fmt.Fprintf(&descr, "space(s) %s", strings.Join(ch.Params.ExposeToSpaces, ","))
 		}
 
@@ -640,6 +643,7 @@ func (ch *ExposeChange) Description() string {
 		}
 
 		if cidrCount != 0 {
+			sort.Strings(ch.Params.ExposeToCIDRs)
 			fmt.Fprintf(&descr, "CIDR(s) %s", strings.Join(ch.Params.ExposeToCIDRs, ","))
 		}
 

--- a/changes_test.go
+++ b/changes_test.go
@@ -579,6 +579,12 @@ func (s *changesSuite) TestSimpleBundle(c *gc.C) {
                 charm: cs:precise/mediawiki-10
                 num_units: 1
                 expose: true
+                exposed-endpoints:
+                  - www
+                expose-to-spaces:
+                  - dmz
+                expose-to-cidrs:
+                  - 13.37.0.0/16
                 options:
                     debug: false
                 annotations:
@@ -645,11 +651,17 @@ func (s *changesSuite) TestSimpleBundle(c *gc.C) {
 		Id:     "expose-2",
 		Method: "expose",
 		Params: bundlechanges.ExposeParams{
-			Application: "$deploy-1",
+			Application:      "$deploy-1",
+			ExposedEndpoints: []string{"www"},
+			ExposeToSpaces:   []string{"dmz"},
+			ExposeToCIDRs:    []string{"13.37.0.0/16"},
 		},
-		GUIArgs: []interface{}{"$deploy-1"},
+		GUIArgs: []interface{}{"$deploy-1", []string{"www"}, []string{"dmz"}, []string{"13.37.0.0/16"}},
 		Args: map[string]interface{}{
-			"application": "$deploy-1",
+			"application":       "$deploy-1",
+			"exposed-endpoints": []interface{}{"www"},
+			"expose-to-spaces":  []interface{}{"dmz"},
+			"expose-to-cidrs":   []interface{}{"13.37.0.0/16"},
 		},
 		Requires: []string{"deploy-1"},
 	}, {
@@ -831,7 +843,7 @@ func (s *changesSuite) TestSimpleBundleWithDevices(c *gc.C) {
 		Params: bundlechanges.ExposeParams{
 			Application: "$deploy-1",
 		},
-		GUIArgs: []interface{}{"$deploy-1"},
+		GUIArgs: []interface{}{"$deploy-1", []string(nil), []string(nil), []string(nil)},
 		Args: map[string]interface{}{
 			"application": "$deploy-1",
 		},
@@ -1020,7 +1032,7 @@ func (s *changesSuite) TestKubernetesBundle(c *gc.C) {
 		Params: bundlechanges.ExposeParams{
 			Application: "$deploy-1",
 		},
-		GUIArgs: []interface{}{"$deploy-1"},
+		GUIArgs: []interface{}{"$deploy-1", []string(nil), []string(nil), []string(nil)},
 		Args: map[string]interface{}{
 			"application": "$deploy-1",
 		},
@@ -1316,7 +1328,7 @@ func (s *changesSuite) TestMachinesAndUnitsPlacementWithBindings(c *gc.C) {
 		Params: bundlechanges.ExposeParams{
 			Application: "$deploy-3",
 		},
-		GUIArgs: []interface{}{"$deploy-3"},
+		GUIArgs: []interface{}{"$deploy-3", []string(nil), []string(nil), []string(nil)},
 		Args: map[string]interface{}{
 			"application": "$deploy-3",
 		},
@@ -3316,7 +3328,13 @@ func (s *changesSuite) TestSimpleBundleEmptyModel(c *gc.C) {
                 applications:
                     django:
                         charm: cs:django-4
-                        expose: yes
+                        expose: true
+                        exposed-endpoints:
+                          - www
+                        expose-to-spaces:
+                          - dmz
+                        expose-to-cidrs:
+                          - 13.37.0.0/16
                         num_units: 1
                         options:
                             key-1: value-1
@@ -3328,7 +3346,7 @@ func (s *changesSuite) TestSimpleBundleEmptyModel(c *gc.C) {
 	expectedChanges := []string{
 		"upload charm cs:django-4",
 		"deploy application django using cs:django-4",
-		"expose django",
+		"expose endpoint(s) www of django to space(s) dmz and CIDR(s) 13.37.0.0/16",
 		"set annotations for django",
 		"add unit django/0 to new machine 0",
 	}
@@ -3342,6 +3360,8 @@ func (s *changesSuite) TestKubernetesBundleEmptyModel(c *gc.C) {
                     django:
                         charm: cs:django-4
                         expose: yes
+                        expose-to-spaces:
+                          - dmz
                         num_units: 1
                         options:
                             key-1: value-1
@@ -3356,7 +3376,7 @@ func (s *changesSuite) TestKubernetesBundleEmptyModel(c *gc.C) {
 	expectedChanges := []string{
 		"upload charm cs:django-4 for series kubernetes",
 		"deploy application django with 1 unit on kubernetes using cs:django-4",
-		"expose django",
+		"expose django to space(s) dmz",
 		"set annotations for django",
 		"upload charm cs:mariadb-5 for series kubernetes",
 		"deploy application mariadb with 2 units on kubernetes using cs:mariadb-5",
@@ -3371,6 +3391,8 @@ func (s *changesSuite) TestCharmInUseByAnotherApplication(c *gc.C) {
                         charm: cs:django-4
                         num_units: 1
                         expose: yes
+                        expose-to-cidrs:
+                          - 13.37.0.0/16
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
@@ -3381,12 +3403,39 @@ func (s *changesSuite) TestCharmInUseByAnotherApplication(c *gc.C) {
 	}
 	expectedChanges := []string{
 		"deploy application django using cs:django-4",
-		"expose django",
+		"expose django to CIDR(s) 13.37.0.0/16",
 		"add unit django/0 to new machine 0",
 	}
 	s.checkBundleExistingModel(c, bundleContent, existingModel, expectedChanges)
 }
 
+func (s *changesSuite) TestExposeWithDifferentParameters(c *gc.C) {
+	bundleContent := `
+                bundle: kubernetes
+                applications:
+                    django:
+                        charm: cs:django-4
+                        num_units: 2
+                        expose: yes
+                        expose-to-cidrs:
+                          - 13.37.0.0/16
+            `
+	existingModel := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"django": {
+				Charm:         "cs:django-4",
+				Scale:         3,
+				Exposed:       true,
+				ExposeToCIDRs: []string{"0.0.0.0/0"},
+			},
+		},
+	}
+	expectedChanges := []string{
+		"expose django to CIDR(s) 13.37.0.0/16",
+		"scale django to 2 units",
+	}
+	s.checkBundleExistingModel(c, bundleContent, existingModel, expectedChanges)
+}
 func (s *changesSuite) TestCharmUpgrade(c *gc.C) {
 	bundleContent := `
                 applications:

--- a/changes_test.go
+++ b/changes_test.go
@@ -3331,6 +3331,7 @@ func (s *changesSuite) TestSimpleBundleEmptyModel(c *gc.C) {
                         expose: true
                         exposed-endpoints:
                           - www
+                          - admin
                         expose-to-spaces:
                           - dmz
                         expose-to-cidrs:
@@ -3346,7 +3347,7 @@ func (s *changesSuite) TestSimpleBundleEmptyModel(c *gc.C) {
 	expectedChanges := []string{
 		"upload charm cs:django-4",
 		"deploy application django using cs:django-4",
-		"expose endpoint(s) www of django to space(s) dmz and CIDR(s) 13.37.0.0/16",
+		"expose endpoint(s) admin,www of django to space(s) dmz and CIDR(s) 13.37.0.0/16",
 		"set annotations for django",
 		"add unit django/0 to new machine 0",
 	}
@@ -3362,6 +3363,7 @@ func (s *changesSuite) TestKubernetesBundleEmptyModel(c *gc.C) {
                         expose: yes
                         expose-to-spaces:
                           - dmz
+                          - public
                         num_units: 1
                         options:
                             key-1: value-1
@@ -3376,7 +3378,7 @@ func (s *changesSuite) TestKubernetesBundleEmptyModel(c *gc.C) {
 	expectedChanges := []string{
 		"upload charm cs:django-4 for series kubernetes",
 		"deploy application django with 1 unit on kubernetes using cs:django-4",
-		"expose django to space(s) dmz",
+		"expose django to space(s) dmz,public",
 		"set annotations for django",
 		"upload charm cs:mariadb-5 for series kubernetes",
 		"deploy application mariadb with 2 units on kubernetes using cs:mariadb-5",
@@ -3419,6 +3421,7 @@ func (s *changesSuite) TestExposeWithDifferentParameters(c *gc.C) {
                         expose: yes
                         expose-to-cidrs:
                           - 13.37.0.0/16
+                          - 0.0.0.0/0
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
@@ -3431,7 +3434,7 @@ func (s *changesSuite) TestExposeWithDifferentParameters(c *gc.C) {
 		},
 	}
 	expectedChanges := []string{
-		"expose django to CIDR(s) 13.37.0.0/16",
+		"expose django to CIDR(s) 0.0.0.0/0,13.37.0.0/16",
 		"scale django to 2 units",
 	}
 	s.checkBundleExistingModel(c, bundleContent, existingModel, expectedChanges)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/juju/bundlechanges v1.0.0 // indirect
-	github.com/juju/charm/v8 v8.0.0-20200817113526-2a88e9b46b47
+	github.com/juju/charm/v8 v8.0.0-20200904115755-136f6163c203
 	github.com/juju/charmrepo/v6 v6.0.0-20200817155725-120bd7a8b1ed
 	github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,10 @@ github.com/juju/charm/v8 v7.0.0-20200424224456-5fe646695e85 h1:YgEB2tnlAwVftOnPU
 github.com/juju/charm/v8 v7.0.0-20200424224456-5fe646695e85/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
 github.com/juju/charm/v8 v8.0.0-20200817113526-2a88e9b46b47 h1:gZlV4PPG+B4iQVBpFalehMueLOrFVj/Qyl/M0rFAOC4=
 github.com/juju/charm/v8 v8.0.0-20200817113526-2a88e9b46b47/go.mod h1:N4PMPMcfLJ4jZaQ2NKfgRb56bcznVZBj5h/RygobR64=
+github.com/juju/charm/v8 v8.0.0-20200904094332-c341cc0a8e16 h1:oChEWFKvVLX3PjTPMkCBRHuU56YbCpdmh4wqGWKNX3g=
+github.com/juju/charm/v8 v8.0.0-20200904094332-c341cc0a8e16/go.mod h1:N4PMPMcfLJ4jZaQ2NKfgRb56bcznVZBj5h/RygobR64=
+github.com/juju/charm/v8 v8.0.0-20200904115755-136f6163c203 h1:XmmDo7neCUOr5h6iGW3XOgrJYZ6ubpSTcYFdeDJjWEM=
+github.com/juju/charm/v8 v8.0.0-20200904115755-136f6163c203/go.mod h1:N4PMPMcfLJ4jZaQ2NKfgRb56bcznVZBj5h/RygobR64=
 github.com/juju/charmrepo v3.0.1+incompatible h1:1PFBr1OofYX9E001FMTa5GF2dZUm2+u0wpQhsOhy0Ec=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09 h1:PJQnY2Ahu3zsaU5chuBZR6z27dyCRwMTicZ/5jGO494=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=

--- a/model.go
+++ b/model.go
@@ -191,16 +191,19 @@ func (m *Model) getUnitMachine(appName string, index int) string {
 
 // Application represents an existing charm deployed in the model.
 type Application struct {
-	Name          string
-	Charm         string // The charm URL.
-	Scale         int
-	Options       map[string]interface{}
-	Annotations   map[string]string
-	Constraints   string // TODO: not updated yet.
-	Exposed       bool
-	SubordinateTo []string
-	Series        string
-	Placement     string
+	Name             string
+	Charm            string // The charm URL.
+	Scale            int
+	Options          map[string]interface{}
+	Annotations      map[string]string
+	Constraints      string // TODO: not updated yet.
+	Exposed          bool
+	ExposedEndpoints []string
+	ExposeToSpaces   []string
+	ExposeToCIDRs    []string
+	SubordinateTo    []string
+	Series           string
+	Placement        string
 	// TODO: handle changes in:
 	//   endpoint bindings -- possible even?
 	//   storage


### PR DESCRIPTION
This PR incorporates the `charm` package changes from https://github.com/juju/charm/pull/315 and https://github.com/juju/charm/pull/316 and updates the change logic to include the expose parameters
when emitting expose changes.

One noticeable change in behavior is that prior to this change, we only emitted an expose change **once** when the expose status of an application changes to `true`. Since the operator can now change some of the expose parameters, the change generator will first check whether the controller model shows the app as already exposed and if that's the case it will compare the individual incoming expose parameters to the ones reported by the controller and emit an expose change in case of a mismatch.