### PR TITLE
Add yaml serialization hints for ExposedEndpoint diff entries

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -328,13 +328,16 @@ func (d *differ) diffExposedEndpoints(bundle map[string]charm.ExposedEndpointSpe
 
 			expDiff := ExposedEndpointDiff{}
 			if foundInBundle {
-				expDiff.Bundle = &ExposedEndpoint{
+				expDiff.Bundle = &ExposedEndpointDiffEntry{
 					ExposeToSpaces: bundleValue.ExposeToSpaces,
 					ExposeToCIDRs:  bundleValue.ExposeToCIDRs,
 				}
 			}
 			if foundInModel {
-				expDiff.Model = &modelValue
+				expDiff.Model = &ExposedEndpointDiffEntry{
+					ExposeToSpaces: modelValue.ExposeToSpaces,
+					ExposeToCIDRs:  modelValue.ExposeToCIDRs,
+				}
 			}
 			result[name] = expDiff
 		}
@@ -552,6 +555,13 @@ func toRelationSlices(relations []Relation) [][]string {
 // settings for a particular endpoint. Nil values indicate that the value
 // was not present in the bundle or model.
 type ExposedEndpointDiff struct {
-	Bundle *ExposedEndpoint `yaml:"bundle"`
-	Model  *ExposedEndpoint `yaml:"model"`
+	Bundle *ExposedEndpointDiffEntry `yaml:"bundle"`
+	Model  *ExposedEndpointDiffEntry `yaml:"model"`
+}
+
+// ExpoExposedEndpointDiffEntry stores the exposed endpoint parameters for
+// an ExposedEndpointDiff entry.
+type ExposedEndpointDiffEntry struct {
+	ExposeToSpaces []string `yaml:"expose_to_spaces,omitempty"`
+	ExposeToCIDRs  []string `yaml:"expose_to_cidrs,omitempty"`
 }

--- a/diff_test.go
+++ b/diff_test.go
@@ -97,32 +97,32 @@ applications:
 			"prometheus": {
 				ExposedEndpoints: map[string]bundlechanges.ExposedEndpointDiff{
 					"bar": {
-						Bundle: &bundlechanges.ExposedEndpoint{
+						Bundle: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToSpaces: []string{"outer"},
 							ExposeToCIDRs:  []string{"42.0.0.0/8"},
 						},
-						Model: &bundlechanges.ExposedEndpoint{
+						Model: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToSpaces: []string{"inner"},
 							ExposeToCIDRs:  []string{"10.0.0.0/24"},
 						},
 					},
 					"baz": {
-						Bundle: &bundlechanges.ExposedEndpoint{
+						Bundle: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToCIDRs: []string{"42.0.0.0/8"},
 						},
-						Model: &bundlechanges.ExposedEndpoint{
+						Model: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToCIDRs: []string{"192.168.0.0/24"},
 						},
 					},
 					"bundle-only": {
-						Bundle: &bundlechanges.ExposedEndpoint{
+						Bundle: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToSpaces: []string{"dmz"},
 						},
 						Model: nil,
 					},
 					"model-only": {
 						Bundle: nil,
-						Model: &bundlechanges.ExposedEndpoint{
+						Model: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToSpaces: []string{"twisted"},
 							ExposeToCIDRs:  []string{"10.0.0.0/24"},
 						},
@@ -675,7 +675,7 @@ func (s *diffSuite) TestApplicationExpose(c *gc.C) {
 				// is *not* exposed.
 				ExposedEndpoints: map[string]bundlechanges.ExposedEndpointDiff{
 					"": {
-						Model: &bundlechanges.ExposedEndpoint{
+						Model: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToCIDRs: []string{"0.0.0.0/0"},
 						},
 					},
@@ -724,11 +724,11 @@ func (s *diffSuite) TestApplicationExposeImplicitCIDRs(c *gc.C) {
 				// endpoints are implicitly exposed to 0.0.0.0/0.
 				ExposedEndpoints: map[string]bundlechanges.ExposedEndpointDiff{
 					"": {
-						Bundle: &bundlechanges.ExposedEndpoint{
+						Bundle: &bundlechanges.ExposedEndpointDiffEntry{
 							// Implicit CIDR as the bundle specifies "expose: true"
 							ExposeToCIDRs: []string{"0.0.0.0/0"},
 						},
-						Model: &bundlechanges.ExposedEndpoint{
+						Model: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToCIDRs: []string{"10.0.0.0/24"},
 						},
 					},


### PR DESCRIPTION
The previous implementation used the model structs for the exposed endpoint diff entries which do not include any serialization hints. As a result, the output looks ugly when marshaled into yaml by the juju cli.

To fix this issue, this PR introduces an extra struct `ExposedEndpointDiffEntry` which provides the yaml hints (unfortunately using underscores to match the exposed_endpoints key in the root diff object)