### PR TITLE
IPV6 friendly expose descriptions and diffs

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -628,7 +628,7 @@ func (ch *ExposeChange) Description() []string {
 	// Easy case: all application gets exposed and no endpoint-specific
 	// parameters are provided.
 	if len(ch.Params.ExposedEndpoints) == 0 {
-		return []string{fmt.Sprintf("expose all endpoints of %s and allow access from CIDR 0.0.0.0/0", ch.Params.appName)}
+		return []string{fmt.Sprintf("expose all endpoints of %s and allow access from CIDRs 0.0.0.0/0 and ::/0", ch.Params.appName)}
 	}
 
 	var (
@@ -672,7 +672,7 @@ func (ch *ExposeChange) Description() []string {
 				fmt.Fprintf(&descr, "CIDR%s %s", plural, strings.Join(exposedGroup.params.ExposeToCIDRs, ","))
 			}
 		} else {
-			fmt.Fprint(&descr, "CIDR 0.0.0.0/0")
+			fmt.Fprint(&descr, "CIDRs 0.0.0.0/0 and ::/0")
 		}
 
 		output = append(output, descr.String())

--- a/changes_test.go
+++ b/changes_test.go
@@ -3414,7 +3414,7 @@ func (s *changesSuite) TestSimpleBundleEmptyModel(c *gc.C) {
 	expectedChanges := []string{
 		"upload charm cs:django-4",
 		"deploy application django using cs:django-4",
-		"expose all endpoints of django and allow access from CIDR 0.0.0.0/0",
+		"expose all endpoints of django and allow access from CIDRs 0.0.0.0/0 and ::/0",
 		"set annotations for django",
 		"add unit django/0 to new machine 0",
 	}
@@ -3442,7 +3442,7 @@ func (s *changesSuite) TestKubernetesBundleEmptyModel(c *gc.C) {
 	expectedChanges := []string{
 		"upload charm cs:django-4 for series kubernetes",
 		"deploy application django with 1 unit on kubernetes using cs:django-4",
-		"expose all endpoints of django and allow access from CIDR 0.0.0.0/0",
+		"expose all endpoints of django and allow access from CIDRs 0.0.0.0/0 and ::/0",
 		"set annotations for django",
 		"upload charm cs:mariadb-5 for series kubernetes",
 		"deploy application mariadb with 2 units on kubernetes using cs:mariadb-5",
@@ -3467,7 +3467,7 @@ func (s *changesSuite) TestCharmInUseByAnotherApplication(c *gc.C) {
 	}
 	expectedChanges := []string{
 		"deploy application django using cs:django-4",
-		"expose all endpoints of django and allow access from CIDR 0.0.0.0/0",
+		"expose all endpoints of django and allow access from CIDRs 0.0.0.0/0 and ::/0",
 		"add unit django/0 to new machine 0",
 	}
 	s.checkBundleExistingModel(c, bundleContent, existingModel, expectedChanges)
@@ -4419,7 +4419,7 @@ func (s *changesSuite) TestMostAppOptions(c *gc.C) {
 	expectedChanges := []string{
 		"upload charm cs:precise/mediawiki-10 for series precise",
 		"deploy application mediawiki on precise using cs:precise/mediawiki-10",
-		"expose all endpoints of mediawiki and allow access from CIDR 0.0.0.0/0",
+		"expose all endpoints of mediawiki and allow access from CIDRs 0.0.0.0/0 and ::/0",
 		"set annotations for mediawiki",
 		"upload charm cs:precise/mysql-28 for series precise",
 		"deploy application mysql on precise using cs:precise/mysql-28",

--- a/diff.go
+++ b/diff.go
@@ -123,14 +123,14 @@ func (d *differ) diffApplication(name string) *ApplicationDiff {
 	if effectiveBundleExpose && len(bundle.ExposedEndpoints) == 0 {
 		bundle.ExposedEndpoints = map[string]charm.ExposedEndpointSpec{
 			allEndpoints: {
-				ExposeToCIDRs: []string{"0.0.0.0/0"},
+				ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"},
 			},
 		}
 	}
 	if effectiveModelExpose && len(model.ExposedEndpoints) == 0 {
 		model.ExposedEndpoints = map[string]ExposedEndpoint{
 			allEndpoints: {
-				ExposeToCIDRs: []string{"0.0.0.0/0"},
+				ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"},
 			},
 		}
 	}

--- a/diff_test.go
+++ b/diff_test.go
@@ -670,13 +670,13 @@ func (s *diffSuite) TestApplicationExpose(c *gc.C) {
 					Model:  true,
 				},
 				// Since the model specifies "expose:true", all
-				// endpoints are exposed to 0.0.0.0/0 which
-				// will show up in the diff given that the bundle
-				// is *not* exposed.
+				// endpoints are exposed to 0.0.0.0/0 and ::/0
+				// which will show up in the diff given that
+				// the bundle is *not* exposed.
 				ExposedEndpoints: map[string]bundlechanges.ExposedEndpointDiff{
 					"": {
 						Model: &bundlechanges.ExposedEndpointDiffEntry{
-							ExposeToCIDRs: []string{"0.0.0.0/0"},
+							ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"},
 						},
 					},
 				},
@@ -725,8 +725,8 @@ func (s *diffSuite) TestApplicationExposeImplicitCIDRs(c *gc.C) {
 				ExposedEndpoints: map[string]bundlechanges.ExposedEndpointDiff{
 					"": {
 						Bundle: &bundlechanges.ExposedEndpointDiffEntry{
-							// Implicit CIDR as the bundle specifies "expose: true"
-							ExposeToCIDRs: []string{"0.0.0.0/0"},
+							// Implicit CIDRs as the bundle specifies "expose: true"
+							ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"},
 						},
 						Model: &bundlechanges.ExposedEndpointDiffEntry{
 							ExposeToCIDRs: []string{"10.0.0.0/24"},


### PR DESCRIPTION
In order to be IPV6-friendly, juju will include both the IPV4 (0.0.0.0/0) and IPV6 (::/0) wildcard CIDRs when generating ingress rules for applications (or individual endpoints) that are exposed to the world.

To this end, this PR revises the description generator for expose changes to include both CIDRs and the diff logic to assume both wildcards are present when diffing against models and/or bundles that indicate an exposed information without any per endpoint expose settings present.