### PR TITLE
Upgrade dependencies for charm and charmrepo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for the bundlechanges library.
 
-PROJECT := github.com/juju/bundlechanges/v4
+PROJECT := github.com/juju/bundlechanges/v5
 
 default: check
 

--- a/changes.go
+++ b/changes.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 )

--- a/changes_test.go
+++ b/changes_test.go
@@ -12,13 +12,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/bundlechanges/v4"
+	"github.com/juju/bundlechanges/v5"
 )
 
 type changesSuite struct {
@@ -139,7 +139,7 @@ func (s *changesSuite) TestMinimalBundleWithChannels(c *gc.C) {
 }
 func (s *changesSuite) TestBundleURLAnnotationSet(c *gc.C) {
 	content := `
-        services:
+        applications:
             django:
                 charm: django`
 

--- a/cmd/get-bundle-changes/main.go
+++ b/cmd/get-bundle-changes/main.go
@@ -10,10 +10,10 @@ import (
 	"io"
 	"os"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/loggo"
 
-	"github.com/juju/bundlechanges/v4"
+	"github.com/juju/bundlechanges/v5"
 )
 
 func main() {

--- a/diff.go
+++ b/diff.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 )

--- a/diff_test.go
+++ b/diff_test.go
@@ -6,14 +6,14 @@ package bundlechanges_test
 import (
 	"strings"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/bundlechanges/v4"
+	"github.com/juju/bundlechanges/v5"
 )
 
 type diffSuite struct {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
-module github.com/juju/bundlechanges/v4
+module github.com/juju/bundlechanges/v5
 
 go 1.14
 
 require (
 	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe // indirect
-	github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0
-	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
+	github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611
+	github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,10 @@ github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sR
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0 h1:BuNV5BMVyKI1XUupcAuC/Y2bW/izfV7Tn+uI7jMYjNk=
-github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
-github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f h1:esltimJsCcUSaC9ahxBpC70Gumqnnmgm0Ah+BLVQBTY=
-github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
+github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611 h1:LQEQJvPHjeFNNAMgQpjthtF0SRzNz2+H/YCK0HmJxs4=
+github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
+github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de h1:95Or6HY8Lfpv007aWUNMKzw2AnDXPOyqQjlO/N3UfjU=
+github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de/go.mod h1:hnCmP2zszIv2WqLZpHyM+4/bkEvDZi5MLHRsvi58Lhs=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=

--- a/handlers.go
+++ b/handlers.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/charm/v8"
-	"github.com/juju/charmrepo/v6"
+	"github.com/juju/charm/v9"
+	"github.com/juju/charmrepo/v7"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"

--- a/model.go
+++ b/model.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v4"
 	"github.com/juju/naturalsort"

--- a/model_test.go
+++ b/model_test.go
@@ -6,7 +6,7 @@ package bundlechanges
 import (
 	"bytes"
 
-	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v9"
 	"github.com/juju/loggo"
 	"github.com/juju/naturalsort"
 	"github.com/juju/testing"


### PR DESCRIPTION
The following upgrades the dependencies for charm and charmrepo. These
repos are locked stepped together and should be merged together at some
point.