### PR TITLE
Expose arch with add charm change

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -55,7 +55,7 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 		// Add the addCharm record if one hasn't been added yet.
 		if charms[application.Charm] == "" && !existing.hasCharm(application.Charm) {
 			// Only parse the architecture constraint once and only if we give
-			// a constraint parser function.
+			// a constraint getter function.
 			var arch string
 			if r.constraintGetter != nil {
 				cons := r.constraintGetter(application.Constraints)


### PR DESCRIPTION
When adding a charm from charm-hub to juju, we now need to know the
architecture. This works fine for most things, but unfotunately we need
this from the bundle as well. Unluckily the arch constraint is for an
application and we need it for adding charms. The two are separated
(addCharm and addApplication) and addCharm is the first one, so we don't
have the constraints to go look in.

The code ensures that we don't leak the whole series of constraints out
at the addCharm level. Instead we allow the passing in of a parser for
application constraints using the config. If the config doesn't have an
arch it falls back to empty (omitting when empty) and works the way it
did previously. Finding one ensures that we get that information.

Additionally I changed the way the description is represented for
upload charm (addCharm) and exposes the architecture we're going to use.