### PR TITLE
Back port add charm architecture

### DIFF
--- a/changes_test.go
+++ b/changes_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/juju/charm/v8"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -3738,6 +3739,30 @@ func (s *changesSuite) TestAppWithArchConstraints(c *gc.C) {
 	s.checkBundleWithConstraintsParser(c, bundleContent, expectedChanges, constraintParser)
 }
 
+func (s *changesSuite) TestAppWithArchConstraintsWithNotFoundError(c *gc.C) {
+	bundleContent := `
+                applications:
+                    django:
+                        charm: cs:django-4
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+            `
+	expectedChanges := []string{
+		"upload charm django from charm-store",
+		"deploy application django from charm-store",
+	}
+	s.checkBundleWithConstraintsParser(c, bundleContent, expectedChanges, constraintParserWithError(errors.NotFoundf("arch")))
+}
+
+func (s *changesSuite) TestAppWithArchConstraintsWithError(c *gc.C) {
+	bundleContent := `
+                applications:
+                    django:
+                        charm: cs:django-4
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+            `
+	s.checkBundleWithConstraintsParserError(c, bundleContent, "bad", constraintParserWithError(errors.Errorf("bad")))
+}
+
 func (s *changesSuite) TestAppWithArchConstraintsWithNoParser(c *gc.C) {
 	bundleContent := `
                 applications:
@@ -5085,8 +5110,12 @@ func (s *changesSuite) checkBundleError(c *gc.C, bundleContent string, errMatch 
 	s.checkBundleImpl(c, bundleContent, nil, nil, errMatch, nil)
 }
 
-func (s *changesSuite) checkBundleWithConstraintsParser(c *gc.C, bundleContent string, expectedChanges []string, parserFn bundlechanges.ArchConstraintParser) {
+func (s *changesSuite) checkBundleWithConstraintsParser(c *gc.C, bundleContent string, expectedChanges []string, parserFn bundlechanges.ConstraintGetter) {
 	s.checkBundleImpl(c, bundleContent, nil, expectedChanges, "", parserFn)
+}
+
+func (s *changesSuite) checkBundleWithConstraintsParserError(c *gc.C, bundleContent, errMatch string, parserFn bundlechanges.ConstraintGetter) {
+	s.checkBundleImpl(c, bundleContent, nil, nil, errMatch, parserFn)
 }
 
 func (s *changesSuite) checkBundleImpl(c *gc.C,
@@ -5094,7 +5123,7 @@ func (s *changesSuite) checkBundleImpl(c *gc.C,
 	existingModel *bundlechanges.Model,
 	expectedChanges []string,
 	errMatch string,
-	parserFn bundlechanges.ArchConstraintParser,
+	parserFn bundlechanges.ConstraintGetter,
 ) {
 	// Retrieve and validate the bundle data merging any overlays in the bundle contents.
 	bundleSrc, err := charm.StreamBundleDataSource(strings.NewReader(bundleContent), "./")
@@ -5106,10 +5135,10 @@ func (s *changesSuite) checkBundleImpl(c *gc.C,
 
 	// Retrieve the changes, and convert them to a sequence of records.
 	changes, err := bundlechanges.FromData(bundlechanges.ChangesConfig{
-		Bundle:               data,
-		Model:                existingModel,
-		Logger:               loggo.GetLogger("bundlechanges"),
-		ArchConstraintParser: parserFn,
+		Bundle:           data,
+		Model:            existingModel,
+		Logger:           loggo.GetLogger("bundlechanges"),
+		ConstraintGetter: parserFn,
 	})
 	if errMatch != "" {
 		c.Assert(err, gc.ErrorMatches, errMatch)
@@ -5130,23 +5159,26 @@ func (s *changesSuite) checkBundleImpl(c *gc.C,
 
 type archConstraint struct {
 	arch string
+	err  error
 }
 
-func (c *archConstraint) HasArch() bool {
-	return c.arch != ""
+func (c *archConstraint) Arch() (string, error) {
+	return c.arch, c.err
 }
 
-func (c *archConstraint) Arch() *string {
-	return &c.arch
-}
-
-func constraintParser(s string) (bundlechanges.ArchConstraint, error) {
+func constraintParser(s string) bundlechanges.ArchConstraint {
 	parts := strings.Split(s, " ")
 	for _, part := range parts {
 		keyValue := strings.Split(part, "=")
 		if len(keyValue) == 2 && keyValue[0] == "arch" {
-			return &archConstraint{arch: keyValue[1]}, nil
+			return &archConstraint{arch: keyValue[1]}
 		}
 	}
-	return &archConstraint{}, nil
+	return &archConstraint{}
+}
+
+func constraintParserWithError(err error) bundlechanges.ConstraintGetter {
+	return func(string) bundlechanges.ArchConstraint {
+		return &archConstraint{err: err}
+	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -55,7 +55,7 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 		// Add the addCharm record if one hasn't been added yet.
 		if charms[application.Charm] == "" && !existing.hasCharm(application.Charm) {
 			// Only parse the architecture constraint once and only if we give
-			// a constraint parser function.
+			// a constraint getter function.
 			var arch string
 			if r.constraintGetter != nil {
 				cons := r.constraintGetter(application.Constraints)


### PR DESCRIPTION
When adding a charm from charm-hub to juju, we now need to know the
architecture. This works fine for most things, but unfotunately we need
this from the bundle as well. Unluckily the arch constraint is for an
application and we need it for adding charms. The two are separated
(addCharm and addApplication) and addCharm is the first one, so we don't
have the constraints to go look in.

The code ensures that we don't leak the whole series of constraints out
at the addCharm level. Instead we allow the passing in of a parser for
application constraints using the config. If the config doesn't have an
arch it falls back to empty (omitting when empty) and works the way it
did previously. Finding one ensures that we get that information.

Additionally I changed the way the description is represented for
upload charm (addCharm) and exposes the architecture we're going to use.