### PR TITLE
Upload application with arch/series constraint

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -62,7 +62,8 @@ func FromData(config ChangesConfig) ([]Change, error) {
 	model := config.Model
 	if model == nil {
 		model = &Model{
-			logger: config.Logger,
+			logger:           config.Logger,
+			ConstraintGetter: config.ConstraintGetter,
 		}
 	}
 	model.initializeSequence()

--- a/changes_test.go
+++ b/changes_test.go
@@ -3508,6 +3508,7 @@ applications:
 				Charm:   "cs:django-4",
 				Scale:   3,
 				Exposed: true,
+				Series:  "kubernetes",
 			},
 		},
 	}
@@ -3546,6 +3547,7 @@ applications:
 				Charm:   "cs:django-4",
 				Scale:   3,
 				Exposed: false,
+				Series:  "kubernetes",
 			},
 		},
 	}
@@ -3578,6 +3580,7 @@ applications:
 				Charm:   "cs:django-4",
 				Scale:   3,
 				Exposed: true,
+				Series:  "kubernetes",
 			},
 		},
 	}
@@ -3651,12 +3654,36 @@ func (s *changesSuite) TestAppExistsWithDifferentScale(c *gc.C) {
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
 			"django": {
+				Charm:  "cs:django-4",
+				Scale:  3,
+				Series: "kubernetes",
+			},
+		},
+	}
+	expectedChanges := []string{
+		"scale django to 2 units",
+	}
+	s.checkBundleExistingModel(c, bundleContent, existingModel, expectedChanges)
+}
+
+func (s *changesSuite) TestAppExistsMissingSeriesWithDifferentScale(c *gc.C) {
+	bundleContent := `
+                bundle: kubernetes
+                applications:
+                    django:
+                        charm: cs:django-4
+                        num_units: 2
+            `
+	existingModel := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"django": {
 				Charm: "cs:django-4",
 				Scale: 3,
 			},
 		},
 	}
 	expectedChanges := []string{
+		"upload charm django from charm-store for series kubernetes",
 		"scale django to 2 units",
 	}
 	s.checkBundleExistingModel(c, bundleContent, existingModel, expectedChanges)
@@ -3723,6 +3750,129 @@ func (s *changesSuite) TestAppWithDifferentConstraints(c *gc.C) {
 		`set constraints for django to "cpu-cores=4 cpu-power=42"`,
 	}
 	s.checkBundleExistingModel(c, bundleContent, existingModel, expectedChanges)
+}
+
+func (s *changesSuite) TestAppsWithArchConstraints(c *gc.C) {
+	bundleContent := `
+                applications:
+                    django-1:
+                        charm: cs:django-4
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                    django-2:
+                        charm: cs:django-4
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+            `
+	expectedChanges := []string{
+		"upload charm django from charm-store with architecture=amd64",
+		"deploy application django-1 from charm-store using django",
+		"upload charm django from charm-store with architecture=s390x",
+		"deploy application django-2 from charm-store using django",
+	}
+	s.checkBundleWithConstraintsParser(c, bundleContent, expectedChanges, constraintParser)
+}
+
+func (s *changesSuite) TestExistingAppsWithArchConstraints(c *gc.C) {
+	bundleContent := `
+                applications:
+                    django-1:
+                        charm: cs:django-4
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                    django-2:
+                        charm: cs:django-4
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+            `
+	existingModel := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"django-1": {
+				Charm: "cs:django-4",
+				Units: []bundlechanges.Unit{
+					{"django/0", "0"},
+				},
+				Constraints: "arch=amd64",
+			},
+		},
+		ConstraintsEqual: func(string, string) bool {
+			return false
+		},
+		ConstraintGetter: constraintParser,
+		Machines: map[string]*bundlechanges.Machine{
+			// We don't actually look at the content of the machines
+			// for this test, just the keys.
+			"0": nil,
+		},
+	}
+	expectedChanges := []string{
+		`set constraints for django-1 to "arch=amd64 cpu-cores=4 cpu-power=42"`,
+		"upload charm django from charm-store with architecture=s390x",
+		"deploy application django-2 from charm-store using django",
+	}
+	s.checkBundleExistingModelWithConstraintsParser(c, bundleContent, existingModel, expectedChanges, constraintParser)
+}
+
+func (s *changesSuite) TestExistingAppsWithoutArchConstraints(c *gc.C) {
+	bundleContent := `
+                applications:
+                    django-1:
+                        charm: cs:django-4
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                    django-2:
+                        charm: cs:django-4
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+            `
+	existingModel := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"django-1": {
+				Charm: "cs:django-4",
+				Units: []bundlechanges.Unit{
+					{"django/0", "0"},
+				},
+				Constraints: "",
+			},
+		},
+		ConstraintsEqual: func(string, string) bool {
+			return false
+		},
+		ConstraintGetter: constraintParser,
+		Machines: map[string]*bundlechanges.Machine{
+			// We don't actually look at the content of the machines
+			// for this test, just the keys.
+			"0": nil,
+		},
+	}
+	expectedChanges := []string{
+		"upload charm django from charm-store with architecture=amd64",
+		`set constraints for django-1 to "arch=amd64 cpu-cores=4 cpu-power=42"`,
+		"upload charm django from charm-store with architecture=s390x",
+		"deploy application django-2 from charm-store using django",
+	}
+	s.checkBundleExistingModelWithConstraintsParser(c, bundleContent, existingModel, expectedChanges, constraintParser)
+}
+
+func (s *changesSuite) TestAppsWithSeriesAndArchConstraints(c *gc.C) {
+	bundleContent := `
+                applications:
+                    django-1:
+                        charm: cs:django-4
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                        series: bionic
+                    django-2:
+                        charm: cs:django-4
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+                        series: bionic
+                    django-3:
+                        charm: cs:django-4
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+                        series: focal
+            `
+	expectedChanges := []string{
+		"upload charm django from charm-store for series bionic with architecture=amd64",
+		"deploy application django-1 from charm-store on bionic using django",
+		"upload charm django from charm-store for series bionic with architecture=s390x",
+		"deploy application django-2 from charm-store on bionic using django",
+		"upload charm django from charm-store for series focal with architecture=s390x",
+		"deploy application django-3 from charm-store on focal using django",
+	}
+	s.checkBundleWithConstraintsParser(c, bundleContent, expectedChanges, constraintParser)
 }
 
 func (s *changesSuite) TestAppWithArchConstraints(c *gc.C) {
@@ -4611,12 +4761,14 @@ func (s *changesSuite) TestAddUnitToExistingApp(c *gc.C) {
 				Units: []bundlechanges.Unit{
 					{"mediawiki/0", "1"},
 				},
+				Series: "precise",
 			},
 			"mysql": {
 				Charm: "cs:precise/mysql-28",
 				Units: []bundlechanges.Unit{
 					{"mysql/0", "0"},
 				},
+				Series: "precise",
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
@@ -4775,6 +4927,7 @@ func (s *changesSuite) TestFromJujuMassiveUnitColocation(c *gc.C) {
 					{Name: "django/0", Machine: "0"},
 					{Name: "django/1", Machine: "0/lxd/0"},
 				},
+				Series: "xenial",
 			},
 			"memcached": {
 				Name:  "memcached",
@@ -4784,6 +4937,7 @@ func (s *changesSuite) TestFromJujuMassiveUnitColocation(c *gc.C) {
 					{Name: "memcached/1", Machine: "1"},
 					{Name: "memcached/2", Machine: "2"},
 				},
+				Series: "xenial",
 			},
 			"ror": {
 				Name:  "ror",
@@ -4793,6 +4947,7 @@ func (s *changesSuite) TestFromJujuMassiveUnitColocation(c *gc.C) {
 					{Name: "ror/1", Machine: "2/kvm/0"},
 					{Name: "ror/2", Machine: "3"},
 				},
+				Series: "xenial",
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
@@ -4874,6 +5029,7 @@ func (s *changesSuite) TestConsistentMapping(c *gc.C) {
 					{Name: "memcached/2", Machine: "2"},
 					{Name: "memcached/3", Machine: "3"},
 				},
+				Series: "xenial",
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
@@ -4916,6 +5072,7 @@ func (s *changesSuite) TestContainerHosts(c *gc.C) {
 				Units: []bundlechanges.Unit{
 					{Name: "memcached/1", Machine: "1"},
 				},
+				Series: "xenial",
 			},
 		},
 		Machines: map[string]*bundlechanges.Machine{
@@ -5112,6 +5269,10 @@ func (s *changesSuite) checkBundleError(c *gc.C, bundleContent string, errMatch 
 
 func (s *changesSuite) checkBundleWithConstraintsParser(c *gc.C, bundleContent string, expectedChanges []string, parserFn bundlechanges.ConstraintGetter) {
 	s.checkBundleImpl(c, bundleContent, nil, expectedChanges, "", parserFn)
+}
+
+func (s *changesSuite) checkBundleExistingModelWithConstraintsParser(c *gc.C, bundleContent string, existingModel *bundlechanges.Model, expectedChanges []string, parserFn bundlechanges.ConstraintGetter) {
+	s.checkBundleImpl(c, bundleContent, existingModel, expectedChanges, "", parserFn)
 }
 
 func (s *changesSuite) checkBundleWithConstraintsParserError(c *gc.C, bundleContent, errMatch string, parserFn bundlechanges.ConstraintGetter) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe // indirect
-	github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0
+	github.com/juju/charm/v8 v8.0.0-20210115122920-fd52ba4d7144
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474/go.mod h1:Qkdc/uu
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0 h1:BuNV5BMVyKI1XUupcAuC/Y2bW/izfV7Tn+uI7jMYjNk=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
+github.com/juju/charm/v8 v8.0.0-20210115122920-fd52ba4d7144 h1:W8Kw/hLYVU5zJc8RvMYfV6Hgas6EgaQ8cZrR7jAGx14=
+github.com/juju/charm/v8 v8.0.0-20210115122920-fd52ba4d7144/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f h1:esltimJsCcUSaC9ahxBpC70Gumqnnmgm0Ah+BLVQBTY=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=


### PR DESCRIPTION
So if an application has existing architecture or series information
then we should set the constraints for the given application. If a
bundle has constraints and series set then the application should upload
a new charm and register a change.

As each charm is a unique blob we have no way to say grab be all of
these series of things, instead we have to upload one at a time
potentially stopping us from getting what we want if one differs
(heterogeneous applications).

The code is rather simple as we've done all the heavy lifting, the
change is to ensure that the key for the application is unique for every
architecture and series.