### PR TITLE
Update charm and charmrepo deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe // indirect
-	github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611
-	github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de
+	github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c
+	github.com/juju/charmrepo/v7 v7.0.0-20210125112315-0c95be42cafc
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,10 @@ github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sR
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611 h1:LQEQJvPHjeFNNAMgQpjthtF0SRzNz2+H/YCK0HmJxs4=
-github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
-github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de h1:95Or6HY8Lfpv007aWUNMKzw2AnDXPOyqQjlO/N3UfjU=
-github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de/go.mod h1:hnCmP2zszIv2WqLZpHyM+4/bkEvDZi5MLHRsvi58Lhs=
+github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c h1:5Apo+om/um+exGB0k3WgFBkeDqstaxU13bF/ITOCYlA=
+github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
+github.com/juju/charmrepo/v7 v7.0.0-20210125112315-0c95be42cafc h1:m4aHwATWf3D9MddTI56S/7cB268zq/oiqH1quJwjnB0=
+github.com/juju/charmrepo/v7 v7.0.0-20210125112315-0c95be42cafc/go.mod h1:R9PTZ6VsweDsg/J2skiWj5ulVpxYPj7JW5IyQxBA4UU=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=


### PR DESCRIPTION
This brings in the v9 charm changes.

Again I'll reiterate, all the following libraries should be inside Juju
package, as they're locked to a version release of Juju:

 - charm
 - charmrepo
 - bundlechanges