### PR TITLE
Merge V4 into master

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -62,7 +62,8 @@ func FromData(config ChangesConfig) ([]Change, error) {
 	model := config.Model
 	if model == nil {
 		model = &Model{
-			logger: config.Logger,
+			logger:           config.Logger,
+			ConstraintGetter: config.ConstraintGetter,
 		}
 	}
 	model.initializeSequence()


### PR DESCRIPTION
Once master was updated to the latest charm and charmrepo dependencies, we can now bring v4 branch into master.

96f5359 (upstream/v4, origin/v4, v4) Merge pull request #79 from SimonRichardson/update-charm-dep
df91c02 Merge pull request #78 from SimonRichardson/add-change-based-on-application-arch
665b333 Merge pull request #77 from SimonRichardson/back-port-add-charm-architecture
