### PR TITLE
Distinguish between creating and updating offers when calculating changes

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -71,7 +71,8 @@ func FromData(config ChangesConfig) ([]Change, error) {
 	}
 
 	deployedBundleApps := alreadyDeployedApplicationsFromBundle(model, config.Bundle.Applications)
-	if addedApplications, err = resolver.handleOffers(addedApplications, deployedBundleApps); err != nil {
+	existingModelOffers := existingOffersFromModel(model)
+	if addedApplications, err = resolver.handleOffers(addedApplications, deployedBundleApps, existingModelOffers); err != nil {
 		return nil, err
 	}
 	resolver.handleRelations(addedApplications)
@@ -102,6 +103,19 @@ func alreadyDeployedApplicationsFromBundle(ctrlModel *Model, bundleApps map[stri
 	}
 
 	return deployedSet.Intersection(bundleSet)
+}
+
+func existingOffersFromModel(ctrlModel *Model) map[string]set.Strings {
+	existingOffers := make(map[string]set.Strings)
+	for _, app := range ctrlModel.Applications {
+		if len(app.Offers) == 0 {
+			continue
+		}
+
+		existingOffers[app.Name] = set.NewStrings(app.Offers...)
+	}
+
+	return existingOffers
 }
 
 // Change holds a single change required to deploy a bundle.
@@ -840,7 +854,11 @@ func (ch *CreateOfferChange) Args() (map[string]interface{}, error) {
 
 // Description implements Change.
 func (ch *CreateOfferChange) Description() string {
-	return fmt.Sprintf("create offer %s using %s:%s", ch.Params.OfferName, ch.Params.Application, strings.Join(ch.Params.Endpoints, ","))
+	verb := "create"
+	if ch.Params.Update {
+		verb = "update"
+	}
+	return fmt.Sprintf("%s offer %s using %s:%s", verb, ch.Params.OfferName, ch.Params.Application, strings.Join(ch.Params.Endpoints, ","))
 }
 
 // CreateOfferParams holds parameters for creating an application offer.
@@ -851,6 +869,8 @@ type CreateOfferParams struct {
 	Endpoints []string `json:"endpoints"`
 	// OfferName describes the offer name.
 	OfferName string `json:"offer-name,omitempty"`
+	// Update is set to true if an existing offer is to be updated.
+	Update bool `json:"update,omitempty"`
 }
 
 // ConsumeOfferChange holds a change for consuming a offer.

--- a/changes_test.go
+++ b/changes_test.go
@@ -491,6 +491,55 @@ applications:
 	s.assertParseData(c, content, expected)
 }
 
+func (s *changesSuite) TestMinimalBundleWithOfferUpdate(c *gc.C) {
+	content := `
+applications:
+  apache2:
+    charm: "cs:apache2-26"
+    offers:
+      offer1:
+        endpoints:
+          - "apache-website"
+          - "apache-proxy"
+   `
+	expected := []record{
+		{
+			Id:     "createOffer-0",
+			Method: "createOffer",
+			Params: bundlechanges.CreateOfferParams{
+				Application: "apache2",
+				Endpoints: []string{
+					"apache-website",
+					"apache-proxy",
+				},
+				OfferName: "offer1",
+				Update:    true,
+			},
+			GUIArgs: []interface{}{"apache2", []string{"apache-website", "apache-proxy"}, "offer1"},
+			Args: map[string]interface{}{
+				"application": "apache2",
+				"endpoints": []interface{}{
+					"apache-website",
+					"apache-proxy",
+				},
+				"offer-name": "offer1",
+				"update":     true,
+			},
+		},
+	}
+
+	curModel := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"apache2": {
+				Name:   "apache2",
+				Charm:  "cs:apache2-26",
+				Offers: []string{"offer1"},
+			},
+		},
+	}
+	s.assertParseDataWithModel(c, curModel, content, expected)
+}
+
 func (s *changesSuite) TestMinimalBundleWithOfferAndRelations(c *gc.C) {
 	content := `
 saas:

--- a/handlers.go
+++ b/handlers.go
@@ -316,7 +316,7 @@ func (r *resolver) handleRelations(addedApplications map[string]string) {
 // handleOffers populates the change set with "CreateOffer" records.
 // ensure we pass back handle offers so that if the map resizes we don't lose
 // applications
-func (r *resolver) handleOffers(addedApplications map[string]string, deployedBundleApplications set.Strings) (map[string]string, error) {
+func (r *resolver) handleOffers(addedApplications map[string]string, deployedBundleApplications set.Strings, existingModelOffers map[string]set.Strings) (map[string]string, error) {
 	// the bundle should have been verified before calling handling of types
 	// as saas applications will stamp on existing applications with the same
 	// name.
@@ -349,10 +349,19 @@ func (r *resolver) handleOffers(addedApplications map[string]string, deployedBun
 				return nil, errors.NotFoundf("cannot create offer %s: application %s", offerName, appName)
 			}
 
+			// If we are updating the offer details and the offered
+			// application is already deployed, we don't have any
+			// requirements.
+			updateOffer := existingModelOffers[appName] != nil && existingModelOffers[appName].Contains(offerName)
+			if updateOffer {
+				reqs = nil
+			}
+
 			change := newCreateOfferChange(CreateOfferParams{
 				Application: appName,
 				Endpoints:   offerSpec.Endpoints,
 				OfferName:   offerName,
+				Update:      updateOffer,
 			}, reqs...)
 			r.changes.add(change)
 

--- a/model.go
+++ b/model.go
@@ -201,6 +201,7 @@ type Application struct {
 	SubordinateTo []string
 	Series        string
 	Placement     string
+	Offers        []string
 	// TODO: handle changes in:
 	//   endpoint bindings -- possible even?
 	//   storage


### PR DESCRIPTION
This PR enhances the controller model definition to include a list of offers for each application. This change allows us to detect whether an offer already exists or whether it needs to be created from scratch. The package indicates this via a new attribute (`Update`) which has been added to `CreateOfferChangeParams`.