### PR TITLE
Handle bundle series

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -135,11 +135,19 @@ func (d *differ) diffApplication(name string) *ApplicationDiff {
 		}
 	}
 
+	// Use the bundle series as the fallback series if the application doesn't
+	// supply a series. This is the same machinery that Juju itself uses to
+	// apply series for applications.
+	bundleSeries := bundle.Series
+	if bundleSeries == "" {
+		bundleSeries = d.config.Bundle.Series
+	}
+
 	result := &ApplicationDiff{
 		Charm:            d.diffStrings(bundle.Charm, model.Charm),
 		Expose:           d.diffBools(effectiveBundleExpose, effectiveModelExpose),
 		ExposedEndpoints: d.diffExposedEndpoints(bundle.ExposedEndpoints, model.ExposedEndpoints),
-		Series:           d.diffStrings(bundle.Series, model.Series),
+		Series:           d.diffStrings(bundleSeries, model.Series),
 		Constraints:      d.diffStrings(bundle.Constraints, model.Constraints),
 		Options:          d.diffOptions(bundle.Options, model.Options),
 	}
@@ -186,9 +194,18 @@ func (d *differ) diffMachines() map[string]*MachineDiff {
 			results[modelID] = &MachineDiff{Missing: ModelSide}
 			continue
 		}
+
+		// Use the bundle series as the fallback series if the machine doesn't
+		// supply a series. This is the same machinery that Juju itself uses to
+		// apply series for machines.
+		bundleSeries := bundleMachine.Series
+		if bundleSeries == "" {
+			bundleSeries = d.config.Bundle.Series
+		}
+
 		diff := &MachineDiff{
 			Series: d.diffStrings(
-				bundleMachine.Series, modelMachine.Series,
+				bundleSeries, modelMachine.Series,
 			),
 		}
 		if d.config.IncludeAnnotations {

--- a/diff_test.go
+++ b/diff_test.go
@@ -502,6 +502,92 @@ func (s *diffSuite) TestApplicationConstraints(c *gc.C) {
 	s.checkDiff(c, bundleContent, model, expectedDiff)
 }
 
+func (s *diffSuite) TestBundleSeries(c *gc.C) {
+	bundleContent := `
+        series: focal
+        applications:
+            prometheus:
+                charm: cs:focal/prometheus-7
+                num_units: 1
+                constraints: something
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:        "prometheus",
+				Charm:       "cs:focal/prometheus-7",
+				Series:      "focal",
+				Constraints: "something",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {
+				ID:     "0",
+				Series: "focal",
+			},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
+func (s *diffSuite) TestNoBundleSeries(c *gc.C) {
+	bundleContent := `
+        applications:
+            prometheus:
+                charm: cs:focal/prometheus-7
+                num_units: 1
+                constraints: something
+                to: [0]
+        machines:
+            0:
+            `
+	model := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"prometheus": {
+				Name:        "prometheus",
+				Charm:       "cs:focal/prometheus-7",
+				Series:      "focal",
+				Constraints: "something",
+				Units: []bundlechanges.Unit{
+					{Name: "prometheus/0", Machine: "0"},
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.Machine{
+			"0": {
+				ID:     "0",
+				Series: "focal",
+			},
+		},
+	}
+	expectedDiff := &bundlechanges.BundleDiff{
+		Applications: map[string]*bundlechanges.ApplicationDiff{
+			"prometheus": {
+				Series: &bundlechanges.StringDiff{
+					Bundle: "",
+					Model:  "focal",
+				},
+			},
+		},
+		Machines: map[string]*bundlechanges.MachineDiff{
+			"0": {
+				Series: &bundlechanges.StringDiff{
+					Bundle: "",
+					Model:  "focal",
+				},
+			},
+		},
+	}
+	s.checkDiff(c, bundleContent, model, expectedDiff)
+}
+
 func (s *diffSuite) TestApplicationOptions(c *gc.C) {
 	bundleContent := `
         applications:


### PR DESCRIPTION
When applying a bundle diff to a model and a bundle we should also take
into account the bundle series. The bundle series should be taken into
account as that is the same mechanism as Juju takes into account and how
bundle themselves parsing works.

This should make it much more efficient when comparing existing bundles
when series fields are empty and global series is filled.