### PR TITLE
Add application channel

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -524,6 +524,7 @@ func (ch *AddApplicationChange) buildArgs(includeDevices bool) []interface{} {
 		endpointBindings,
 		resources,
 		ch.Params.NumUnits,
+		ch.Params.Channel,
 	}
 	if !includeDevices {
 		// delete devices after storage
@@ -539,11 +540,15 @@ func (ch *AddApplicationChange) GUIArgs() []interface{} {
 
 // Description implements Change.
 func (ch *AddApplicationChange) Description() []string {
-	series := ""
+	var series string
 	if ch.Params.Series != "" {
 		series = " on " + ch.Params.Series
 	}
-	unitsInfo := ""
+	var channel string
+	if ch.Params.Channel != "" {
+		channel = " with " + ch.Params.Channel
+	}
+	var unitsInfo string
 	if ch.Params.NumUnits > 0 {
 		plural := ""
 		if ch.Params.NumUnits > 1 {
@@ -565,7 +570,7 @@ func (ch *AddApplicationChange) Description() []string {
 		}
 	}
 
-	return []string{fmt.Sprintf("deploy application %s%s%s%s%s", ch.Params.Application, location, unitsInfo, series, using)}
+	return []string{fmt.Sprintf("deploy application %s%s%s%s%s%s", ch.Params.Application, location, unitsInfo, series, channel, using)}
 }
 
 // AddApplicationParams holds parameters for deploying a Juju application.
@@ -597,6 +602,8 @@ type AddApplicationParams struct {
 	// LocalResources identifies the path to the local resource
 	// of the application's charm.
 	LocalResources map[string]string `json:"local-resources,omitempty"`
+	// Channel holds the channel of the application to be deployed.
+	Channel string `json:"channel,omitempty"`
 
 	// The public Charm holds either the charmURL of a placeholder for the
 	// add charm change.

--- a/changes_test.go
+++ b/changes_test.go
@@ -81,6 +81,7 @@ func (s *changesSuite) TestMinimalBundle(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -117,6 +118,7 @@ func (s *changesSuite) TestMinimalBundleWithChannels(c *gc.C) {
 		Params: bundlechanges.AddApplicationParams{
 			Charm:       "$addCharm-0",
 			Application: "django",
+			Channel:     "edge",
 		},
 		GUIArgs: []interface{}{
 			"$addCharm-0",
@@ -128,10 +130,12 @@ func (s *changesSuite) TestMinimalBundleWithChannels(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"edge",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
 			"charm":       "$addCharm-0",
+			"channel":     "edge",
 		},
 		Requires: []string{"addCharm-0"},
 	}}
@@ -168,6 +172,7 @@ func (s *changesSuite) TestBundleURLAnnotationSet(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -249,6 +254,7 @@ func (s *changesSuite) TestMinimalBundleWithDevices(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -306,6 +312,7 @@ applications:
 				map[string]string{},
 				map[string]int{},
 				0,
+				"",
 			},
 			Args: map[string]interface{}{
 				"application": "apache2",
@@ -451,6 +458,7 @@ applications:
 				map[string]string{},
 				map[string]int{},
 				0,
+				"",
 			},
 			Args: map[string]interface{}{
 				"application": "apache2",
@@ -594,6 +602,7 @@ relations:
 				map[string]string{},
 				map[string]int{},
 				0,
+				"",
 			},
 			Args: map[string]interface{}{
 				"application": "apache2",
@@ -690,6 +699,7 @@ func (s *changesSuite) TestSimpleBundle(c *gc.C) {
 			map[string]string{},
 			map[string]int{"data": 3},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mediawiki",
@@ -767,6 +777,7 @@ func (s *changesSuite) TestSimpleBundle(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mysql",
@@ -874,6 +885,7 @@ func (s *changesSuite) TestSimpleBundleWithDevices(c *gc.C) {
 			map[string]string{},
 			map[string]int{"data": 3},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mediawiki",
@@ -952,6 +964,7 @@ func (s *changesSuite) TestSimpleBundleWithDevices(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mysql",
@@ -1062,6 +1075,7 @@ func (s *changesSuite) TestKubernetesBundle(c *gc.C) {
 			map[string]string{},
 			map[string]int{"data": 3},
 			1,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mediawiki",
@@ -1142,6 +1156,7 @@ func (s *changesSuite) TestKubernetesBundle(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			2,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mysql",
@@ -1210,6 +1225,7 @@ func (s *changesSuite) TestSameCharmReused(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mediawiki",
@@ -1235,6 +1251,7 @@ func (s *changesSuite) TestSameCharmReused(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "otherwiki",
@@ -1318,6 +1335,7 @@ func (s *changesSuite) TestMachinesAndUnitsPlacementWithBindings(c *gc.C) {
 			map[string]string{"": "foo", "http": "bar"},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -1361,6 +1379,7 @@ func (s *changesSuite) TestMachinesAndUnitsPlacementWithBindings(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "haproxy",
@@ -1564,6 +1583,7 @@ func (s *changesSuite) TestMachinesWithConstraintsAndAnnotations(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -1693,6 +1713,7 @@ func (s *changesSuite) TestEndpointWithoutRelationName(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mediawiki",
@@ -1731,6 +1752,7 @@ func (s *changesSuite) TestEndpointWithoutRelationName(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "mysql",
@@ -1798,6 +1820,7 @@ func (s *changesSuite) TestUnitPlacedInApplication(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -1832,6 +1855,7 @@ func (s *changesSuite) TestUnitPlacedInApplication(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "wordpress",
@@ -1944,6 +1968,7 @@ func (s *changesSuite) TestUnitPlacedInApplicationWithDevices(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -1979,6 +2004,7 @@ func (s *changesSuite) TestUnitPlacedInApplicationWithDevices(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "wordpress",
@@ -2104,6 +2130,7 @@ func (s *changesSuite) TestUnitColocationWithOtherUnits(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -2141,6 +2168,7 @@ func (s *changesSuite) TestUnitColocationWithOtherUnits(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "memcached",
@@ -2178,6 +2206,7 @@ func (s *changesSuite) TestUnitColocationWithOtherUnits(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "ror",
@@ -2508,6 +2537,7 @@ func (s *changesSuite) TestUnitPlacedToMachines(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -2723,6 +2753,7 @@ func (s *changesSuite) TestUnitPlacedToNewMachineWithConstraints(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -2813,6 +2844,7 @@ func (s *changesSuite) TestApplicationWithStorage(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -2905,6 +2937,7 @@ func (s *changesSuite) TestApplicationWithDevices(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -2981,6 +3014,7 @@ func (s *changesSuite) TestApplicationWithEndpointBindings(c *gc.C) {
 			map[string]string{"foo": "bar"},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -3035,6 +3069,7 @@ applications:
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -3113,6 +3148,7 @@ machines:
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "gui3",
@@ -3341,6 +3377,7 @@ func (s *changesSuite) assertLocalBundleChanges(c *gc.C, charmDir, bundleContent
 			map[string]string{},      // endpoint bindings.
 			map[string]int{},         // resources.
 			0,                        // num_units.
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",
@@ -3384,6 +3421,7 @@ func (s *changesSuite) assertLocalBundleChangesWithDevices(c *gc.C, charmDir, bu
 			map[string]string{},      // endpoint bindings.
 			map[string]int{},         // resources.
 			0,                        // num_units.
+			"",
 		},
 		Args: map[string]interface{}{
 			"application": "django",

--- a/model.go
+++ b/model.go
@@ -48,6 +48,7 @@ type Model struct {
 	logger Logger
 }
 
+// Relation holds the information between two releations.
 type Relation struct {
 	App1      string
 	Endpoint1 string
@@ -153,7 +154,7 @@ func topLevelMachine(machineID string) string {
 }
 
 // InferMachineMap looks at all the machines defined in the bundle
-// and ifers their mapping to the existing machine.
+// and infers their mapping to the existing machine.
 // This method assumes that the units of an application are sorted
 // in the natural sort order, meaning we start at unit zero and work
 // our way up the unit numbers.
@@ -167,7 +168,7 @@ func (m *Model) InferMachineMap(data *charm.BundleData) {
 }
 
 // BundleMachine will return a the existing machine for the specified bundle
-// amchine ID. If there is not a mapping available, nil is returned.
+// machine ID. If there is not a mapping available, nil is returned.
 func (m *Model) BundleMachine(id string) *Machine {
 	if m.Machines == nil {
 		return nil
@@ -248,8 +249,8 @@ func (m *Model) hasCharm(charm string) bool {
 	return false
 }
 
-func (m *Model) hasCharmWithArchAndSeries(charm, arch, series string) bool {
-	if arch == "" && series == "" {
+func (m *Model) matchesCharmPermutation(charm, arch, series, channel string) bool {
+	if arch == "" && series == "" && channel == "" {
 		return m.hasCharm(charm)
 	}
 
@@ -265,7 +266,7 @@ func (m *Model) hasCharmWithArchAndSeries(charm, arch, series string) bool {
 			}
 		}
 
-		if app.Charm == charm && appArch == arch && app.Series == series {
+		if app.Charm == charm && appArch == arch && app.Series == series && app.Channel == channel {
 			return true
 		}
 	}


### PR DESCRIPTION
Juju needs to know more about channels that an application can be given
and because of the way addCharm and addApplication is split it becomes
harder to understand the key change.

The code is simple, expose channel in the same way that series is on the
application and push it through the code.

There already exists a test for channels, so modifying that to show the
right thing was easy.