### PR TITLE
Pass channel back when resolving.

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -31,8 +31,9 @@ type ArchConstraint interface {
 // ConstraintGetter represents a architecture constraint parser.
 type ConstraintGetter func(string) ArchConstraint
 
-// RevisionGetter resolves the revision of a charm from the list of parameters.
-type RevisionGetter func(charm string, series string, channel string, arch string) (int, error)
+// CharmResolver resolves the channel and revision of a charm from the list of
+// parameters.
+type CharmResolver func(charm string, series string, channel string, arch string) (string, int, error)
 
 // ChangesConfig is used to provide the required data for determining changes.
 type ChangesConfig struct {
@@ -41,7 +42,7 @@ type ChangesConfig struct {
 	Logger           Logger
 	BundleURL        string
 	ConstraintGetter ConstraintGetter
-	RevisionGetter   RevisionGetter
+	CharmResolver    CharmResolver
 	Force            bool
 	// TODO: add charm metadata for validation.
 }
@@ -80,7 +81,7 @@ func FromData(config ChangesConfig) ([]Change, error) {
 		bundleURL:        config.BundleURL,
 		logger:           config.Logger,
 		constraintGetter: config.ConstraintGetter,
-		revisionGetter:   config.RevisionGetter,
+		charmResolver:    config.CharmResolver,
 		changes:          changes,
 		force:            config.Force,
 	}

--- a/changes_test.go
+++ b/changes_test.go
@@ -3779,8 +3779,8 @@ func (s *changesSuite) TestCharmUpgradeWithCharmhubCharmAndExistingChannel(c *gc
 	expectedChanges := []string{
 		"upgrade django from charm-hub using charm django from channel stable",
 	}
-	s.checkBundleExistingModelWithRevisionParser(c, bundleContent, existingModel, expectedChanges, func(string, string, string, string) (int, error) {
-		return 42, nil
+	s.checkBundleExistingModelWithRevisionParser(c, bundleContent, existingModel, expectedChanges, func(string, string, string, string) (string, int, error) {
+		return "stable", 42, nil
 	})
 }
 
@@ -5448,8 +5448,8 @@ func (s *changesSuite) checkBundleWithConstraintsParserError(c *gc.C, bundleCont
 	s.checkBundleImpl(c, bundleContent, nil, nil, errMatch, parserFn, nil)
 }
 
-func (s *changesSuite) checkBundleExistingModelWithRevisionParser(c *gc.C, bundleContent string, existingModel *bundlechanges.Model, expectedChanges []string, revisionFn bundlechanges.RevisionGetter) {
-	s.checkBundleImpl(c, bundleContent, existingModel, expectedChanges, "", nil, revisionFn)
+func (s *changesSuite) checkBundleExistingModelWithRevisionParser(c *gc.C, bundleContent string, existingModel *bundlechanges.Model, expectedChanges []string, charmResolverFn bundlechanges.CharmResolver) {
+	s.checkBundleImpl(c, bundleContent, existingModel, expectedChanges, "", nil, charmResolverFn)
 }
 
 func (s *changesSuite) checkBundleImpl(c *gc.C,
@@ -5458,7 +5458,7 @@ func (s *changesSuite) checkBundleImpl(c *gc.C,
 	expectedChanges []string,
 	errMatch string,
 	parserFn bundlechanges.ConstraintGetter,
-	revisionFn bundlechanges.RevisionGetter,
+	charmResolverFn bundlechanges.CharmResolver,
 ) {
 	// Retrieve and validate the bundle data merging any overlays in the bundle contents.
 	bundleSrc, err := charm.StreamBundleDataSource(strings.NewReader(bundleContent), "./")
@@ -5474,7 +5474,7 @@ func (s *changesSuite) checkBundleImpl(c *gc.C,
 		Model:            existingModel,
 		Logger:           loggo.GetLogger("bundlechanges"),
 		ConstraintGetter: parserFn,
-		RevisionGetter:   revisionFn,
+		CharmResolver:    charmResolverFn,
 	})
 	if errMatch != "" {
 		c.Assert(err, gc.ErrorMatches, errMatch)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -45,8 +45,8 @@ func (s *resolverSuite) TestAllowUpgradeWithSameChannel(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		revisionGetter: func(charm, series, channel, arch string) (int, error) {
-			return 1, nil
+		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+			return "stable", 1, nil
 		},
 	}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
@@ -68,8 +68,8 @@ func (s *resolverSuite) TestAllowUpgradeWithDowngrades(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		revisionGetter: func(charm, series, channel, arch string) (int, error) {
-			return 1, nil
+		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+			return "stable", 1, nil
 		},
 	}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
@@ -91,8 +91,8 @@ func (s *resolverSuite) TestAllowUpgradeWithSameRevision(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		revisionGetter: func(charm, series, channel, arch string) (int, error) {
-			return 1, nil
+		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+			return "stable", 1, nil
 		},
 	}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
@@ -117,6 +117,22 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannel(c *gc.C) {
 	c.Assert(ok, jc.IsFalse)
 }
 
+func (s *resolverSuite) TestAllowUpgradeWithNoChannel(c *gc.C) {
+	existing := &Application{
+		Charm:   "ch:ubuntu",
+		Channel: "stable",
+	}
+	requested := &charm.ApplicationSpec{
+		Charm: "ch:ubuntu",
+	}
+	requestedArch := "amd64"
+
+	r := resolver{}
+	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
+	c.Assert(err, gc.ErrorMatches, `^upgrades not supported across channels \(existing: "stable", resolved: ""\); use --force to override`)
+	c.Assert(ok, jc.IsFalse)
+}
+
 func (s *resolverSuite) TestAllowUpgradeWithDifferentChannelAndForce(c *gc.C) {
 	existing := &Application{
 		Charm:    "ch:ubuntu",
@@ -131,8 +147,8 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannelAndForce(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		revisionGetter: func(charm, series, channel, arch string) (int, error) {
-			return 1, nil
+		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+			return "stable", 1, nil
 		},
 	}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)


### PR DESCRIPTION
The following changes updates the revision getter to now pass back the
channel. Updating any code to ensure that we rename any old naming to
the new one.

Unfortunately we have to request the channel before we can check the
equality, previously we checked just the channels. This became a problem
when the existing application had been resolved even if the channel was
empty, yet the bundle was still shown to be empty. Effectively
preventing the deployment of bundles with empty channels. The new unit
tests ensure we get the correct error message based on the content of
the model and the bundle.