### PR TITLE
Handle talking to older controllers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -247,6 +247,12 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 	if existingApp.Revision == -1 {
 		return false, nil
 	}
+	// This handles the case that the existing application doesn't have a
+	// channel, so we're talking to an older controller. In that situation the
+	// older path way would ignore channel upgrades.
+	if existingApp.Channel == "" {
+		return false, nil
+	}
 
 	var (
 		resolvedChan = bundleApp.Channel

--- a/handlers.go
+++ b/handlers.go
@@ -248,10 +248,18 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		return false, nil
 	}
 	// This handles the case that the existing application doesn't have a
-	// channel, so we're talking to an older controller. In that situation the
-	// older path way would ignore channel upgrades.
+	// channel, so we're talking to an older controller.
 	if existingApp.Channel == "" {
-		return false, nil
+		// No upgrade required.
+		if bundleApp.Channel == "" {
+			return false, nil
+		}
+		// If the bundle channel is not empty and we're not using force, then
+		// raise an error asking the user to supply force.
+		if !r.force && bundleApp.Channel != "" {
+			return false, errors.Errorf("upgrades not supported with unknown existing channels; use --force to override")
+		}
+		return true, nil
 	}
 
 	var (

--- a/handlers.go
+++ b/handlers.go
@@ -257,7 +257,7 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		// If the bundle channel is not empty and we're not using force, then
 		// raise an error asking the user to supply force.
 		if !r.force && bundleApp.Channel != "" {
-			return false, errors.Errorf("upgrades not supported with unknown existing channels; use --force to override")
+			return false, errors.Errorf("upgrades not supported when the channel for the deployed application is unknown; use --force to override")
 		}
 		return true, nil
 	}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -117,7 +117,7 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannel(c *gc.C) {
 	c.Assert(ok, jc.IsFalse)
 }
 
-func (s *resolverSuite) TestAllowUpgradeWithNoChannel(c *gc.C) {
+func (s *resolverSuite) TestAllowUpgradeWithNoBundleChannel(c *gc.C) {
 	existing := &Application{
 		Charm:   "ch:ubuntu",
 		Channel: "stable",
@@ -154,4 +154,20 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannelAndForce(c *gc.C) {
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannel(c *gc.C) {
+	existing := &Application{
+		Charm: "ch:ubuntu",
+	}
+	requested := &charm.ApplicationSpec{
+		Charm:   "ch:ubuntu",
+		Channel: "stable",
+	}
+	requestedArch := "amd64"
+
+	r := resolver{}
+	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsFalse)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -168,6 +168,24 @@ func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, `^upgrades not supported with unknown existing channels; use --force to override`)
 	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannelWithForce(c *gc.C) {
+	existing := &Application{
+		Charm: "ch:ubuntu",
+	}
+	requested := &charm.ApplicationSpec{
+		Charm:   "ch:ubuntu",
+		Channel: "stable",
+	}
+	requestedArch := "amd64"
+
+	r := resolver{
+		force: true,
+	}
+	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsTrue)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -168,7 +168,7 @@ func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `^upgrades not supported with unknown existing channels; use --force to override`)
+	c.Assert(err, gc.ErrorMatches, `^upgrades not supported when the channel for the deployed application is unknown; use --force to override`)
 	c.Assert(ok, jc.IsFalse)
 }
 


### PR DESCRIPTION
Older controllers ignored channels and so should we when looking at
existing information.

The code just bails out if we're speaking to an older controller.